### PR TITLE
Image + Gif loading optimizations

### DIFF
--- a/src/main/java/com/creativemd/opf/block/TileEntityPicFrame.java
+++ b/src/main/java/com/creativemd/opf/block/TileEntityPicFrame.java
@@ -4,283 +4,280 @@ import com.creativemd.creativecore.common.tileentity.TileEntityCreative;
 import com.creativemd.creativecore.common.utils.CubeObject;
 import com.creativemd.opf.client.DownloadThread;
 import com.creativemd.opf.client.PictureTexture;
-
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockRotatedPillar;
-import net.minecraft.init.Blocks;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.network.NetworkManager;
-import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class TileEntityPicFrame extends TileEntityCreative{
-	
-	public TileEntityPicFrame() {
-		if(FMLCommonHandler.instance().getSide().isClient())
-			initClient();
-	}
-	
-	@SideOnly(Side.CLIENT)
-	public DownloadThread downloader;
-	
-	@SideOnly(Side.CLIENT)
-	public PictureTexture texture;
-	
-	@SideOnly(Side.CLIENT)
-	public boolean failed;
-	
-	@SideOnly(Side.CLIENT)
-	public void initClient()
-	{
-		texture = null;
-		failed = false;
-	}
-	
-	@SideOnly(Side.CLIENT)
-	public boolean shouldLoadTexture()
-	{
-		return !isTextureLoaded() && !failed;
-	}
-	
-	@SideOnly(Side.CLIENT)
-	public void loadTexutre()
-	{
-		if(shouldLoadTexture())
-		{
-			if(downloader == null)
-			{
-				PictureTexture loadedTexture = DownloadThread.loadedImages.get(url);
-				
-				if(loadedTexture == null)
-				{
-					if(!DownloadThread.loadingImages.contains(url))
-					{
-						DownloadThread.loadingImages.add(url);
-						downloader = new DownloadThread(url);
-					}
-				}
-				else
-					texture = loadedTexture;
-			}
-			if(downloader != null && downloader.hasFinished())
-			{
-				if(downloader.hasFailed())
-					failed = true;
-				else
-					texture = DownloadThread.loadImage(downloader);
-				DownloadThread.loadingImages.remove(url);
-				downloader = null;
-			}
-		}
-	}
-	
-	@SideOnly(Side.CLIENT)
-	public boolean isTextureLoaded()
-	{
-		return texture != null;
-	}
-	
-	@Override
-	@SideOnly(Side.CLIENT)
-    public double getMaxRenderDistanceSquared()
-    {
-        return Math.pow(renderDistance, 2);
-    }
-	
-	public static AxisAlignedBB getBoundingBox(TileEntityPicFrame frame, int meta)
-	{
-		/*AxisAlignedBB bb = INFINITE_EXTENT_AABB;
-        return bb;*/
-		CubeObject cube = new CubeObject(0, 0, 0, 0.05F, 1, 1);
-		
-		float sizeX = frame.sizeX;
-		if(sizeX == 0)
-			sizeX = 1;
-		float sizeY = frame.sizeY;
-		if(sizeY == 0)
-			sizeY = 1;
-		double offsetX = 0;
-		double offsetY = 0;
-		
-		switch(frame.rotation)
-		{
-		case 1:
-			sizeX = frame.sizeY;
-			sizeY = -frame.sizeX;
-			if(frame.posY == 0)
-				offsetY += 1;
-			else if(frame.posY == 2)
-				offsetY -= 1;
-			break;
-		case 2:
-			sizeX = -frame.sizeX;
-			sizeY = -frame.sizeY;
-			if(frame.posX == 0)
-				offsetX += 1;
-			else if(frame.posX == 2)
-				offsetX -= 1;
-			if(frame.posY == 0)
-				offsetY += 1;
-			else if(frame.posY == 2)
-				offsetY -= 1;
-			break;
-		case 3:
-			sizeX = -frame.sizeY;
-			sizeY = frame.sizeX;
-			if(frame.posX == 0)
-				offsetX += 1;
-			else if(frame.posX == 2)
-				offsetX -= 1;
-			break;
-		}
-		
-		if(frame.posX == 1)
-			offsetX += (-sizeX+1)/2D;
-		else if(frame.posX == 2)
-			offsetX += -sizeX+1;
-		
-		
-		if(frame.posY == 1)
-			offsetY += (-sizeY+1)/2D;
-		else if(frame.posY == 2)
-			offsetY += -sizeY+1;
-		
-		EnumFacing direction = EnumFacing.getFront(meta);
-		if(direction == EnumFacing.UP)
-		{
-			cube.minZ -= sizeX-1;
-			cube.minY -= sizeY-1;
-			
-			cube.minZ -= offsetX;
-			cube.maxZ -= offsetX;
-			cube.minY -= offsetY;
-			cube.maxY -= offsetY;
-		}else{
-			cube.maxZ += sizeX-1;
-			cube.maxY += sizeY-1;
-			
-			cube.minZ += offsetX;
-			cube.maxZ += offsetX;
-			cube.minY += offsetY;
-			cube.maxY += offsetY;
-		}
-		
-		cube = new CubeObject(Math.min(cube.minX, cube.maxX), Math.min(cube.minY, cube.maxY), Math.min(cube.minZ, cube.maxZ),
-				Math.max(cube.minX, cube.maxX), Math.max(cube.minY, cube.maxY), Math.max(cube.minZ, cube.maxZ));
-		
-        return CubeObject.rotateCube(cube, direction).getAxis();
-	}
-	
-	@Override
-	@SideOnly(Side.CLIENT)
-    public AxisAlignedBB getRenderBoundingBox()
-    {
-        return getBoundingBox(this, getBlockMetadata()).offset(pos);
-    }
-	
-	public int renderDistance = 512;
-	
-	public String url = "";
-	public float sizeX = 1F;
-	public float sizeY = 1F;
-	
-	public boolean flippedX;
-	public boolean flippedY;
-	
-	/**-90 to 90**/
-	public float rotationX;
-	/**-90 to 90**/
-	public float rotationY;
-	
-	/**0-3 all directions**/
-	public byte rotation = 0;
-	
-	/**0: normal,1: center, 2: -normal**/
-	public byte posX = 0;
-	/**0: normal,1: center, 2: -normal**/
-	public byte posY = 0;
-	
-	public boolean visibleFrame = true;
-	
-	
-	@Override
-	public NBTTagCompound writeToNBT(NBTTagCompound nbt)
-	{
-		nbt = super.writeToNBT(nbt);
-		nbt.setString("url", url);
-		nbt.setFloat("sizeX", sizeX);
-		nbt.setFloat("sizeY", sizeY);
-		nbt.setInteger("render", renderDistance);
-		nbt.setByte("offsetX", posX);
-		nbt.setByte("offsetY", posY);
-		nbt.setByte("rotation", rotation);
-		nbt.setBoolean("visibleFrame", visibleFrame);
-		nbt.setBoolean("flippedX", flippedX);
-		nbt.setBoolean("flippedY", flippedY);
-		nbt.setFloat("rotX", rotationX);
-		nbt.setFloat("rotY", rotationY);
-		return nbt;
-	}
-	
-	@Override
-	public void readFromNBT(NBTTagCompound nbt)
-	{
-		super.readFromNBT(nbt);
-		url = nbt.getString("url");
-		sizeX = nbt.getFloat("sizeX");
-		sizeY = nbt.getFloat("sizeY");
-		renderDistance = nbt.getInteger("render");
-		posX = nbt.getByte("offsetX");
-		posY = nbt.getByte("offsetY");
-		rotation = nbt.getByte("rotation");
-		visibleFrame = nbt.getBoolean("visibleFrame");
-		flippedX = nbt.getBoolean("flippedX");
-		flippedY = nbt.getBoolean("flippedY");
-		rotationX = nbt.getFloat("rotX");
-		rotationY = nbt.getFloat("rotY");
-	}
-	
-	@Override
-	public void getDescriptionNBT(NBTTagCompound nbt)
-	{
-		super.getDescriptionNBT(nbt);
-		nbt.setString("url", url);
-		nbt.setFloat("sizeX", sizeX);
-		nbt.setFloat("sizeY", sizeY);
-		nbt.setInteger("render", renderDistance);
-		nbt.setByte("offsetX", posX);
-		nbt.setByte("offsetY", posY);
-		nbt.setByte("rotation", rotation);
-		nbt.setBoolean("visibleFrame", visibleFrame);
-		nbt.setBoolean("flippedX", flippedX);
-		nbt.setBoolean("flippedY", flippedY);
-		nbt.setFloat("rotX", rotationX);
-		nbt.setFloat("rotY", rotationY);
-	}
-	
-	@Override
-	@SideOnly(Side.CLIENT)
-	public void receiveUpdatePacket(NBTTagCompound nbt)
-	{
-		super.receiveUpdatePacket(nbt);
-		url = nbt.getString("url");
-		sizeX = nbt.getFloat("sizeX");
-		sizeY = nbt.getFloat("sizeY");
-		renderDistance = nbt.getInteger("render");
-		posX = nbt.getByte("offsetX");
-		posY = nbt.getByte("offsetY");
-		rotation = nbt.getByte("rotation");
-		visibleFrame = nbt.getBoolean("visibleFrame");
-		flippedX = nbt.getBoolean("flippedX");
-		flippedY = nbt.getBoolean("flippedY");
-		rotationX = nbt.getFloat("rotX");
-		rotationY = nbt.getFloat("rotY");
-		initClient();
-		updateRender();
+public class TileEntityPicFrame extends TileEntityCreative {
+
+    public TileEntityPicFrame() {
+        if (FMLCommonHandler.instance().getSide().isClient()) {
+            initClient();
+        }
     }
 
+    @SideOnly(Side.CLIENT)
+    public DownloadThread downloader;
+
+    @SideOnly(Side.CLIENT)
+    public PictureTexture texture;
+
+    @SideOnly(Side.CLIENT)
+    public boolean failed;
+
+    @SideOnly(Side.CLIENT)
+    public void initClient() {
+        texture = null;
+        failed = false;
+    }
+
+    @SideOnly(Side.CLIENT)
+    public boolean shouldLoadTexture() {
+        return !isTextureLoaded() && !failed;
+    }
+
+    @SideOnly(Side.CLIENT)
+    public void loadTexture() {
+        if (shouldLoadTexture()) {
+            if (downloader == null && DownloadThread.activeDownloads < DownloadThread.MAXIMUM_ACTIVE_DOWNLOADS) {
+                PictureTexture loadedTexture = DownloadThread.loadedImages.get(url);
+
+                if (loadedTexture == null) {
+                    if (!DownloadThread.loadingImages.contains(url)) {
+                        synchronized (DownloadThread.LOCK) {
+                            DownloadThread.loadingImages.add(url);
+                        }
+                        downloader = new DownloadThread(url);
+                    }
+                } else {
+                    texture = loadedTexture;
+                }
+            }
+            if (downloader != null && downloader.hasFinished()) {
+                if (downloader.hasFailed()) {
+                    failed = true;
+                } else {
+                    texture = DownloadThread.loadImage(downloader);
+                }
+                synchronized (DownloadThread.LOCK) {
+                    DownloadThread.loadingImages.remove(url);
+                }
+                downloader = null;
+            }
+        }
+    }
+
+    @SideOnly(Side.CLIENT)
+    public boolean isTextureLoaded() {
+        return texture != null;
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public double getMaxRenderDistanceSquared() {
+        return Math.pow(renderDistance, 2);
+    }
+
+    public static AxisAlignedBB getBoundingBox(TileEntityPicFrame frame, int meta) {
+        /*AxisAlignedBB bb = INFINITE_EXTENT_AABB;
+        return bb;*/
+        CubeObject cube = new CubeObject(0, 0, 0, 0.05F, 1, 1);
+
+        float sizeX = frame.sizeX;
+        if (sizeX == 0) {
+            sizeX = 1;
+        }
+        float sizeY = frame.sizeY;
+        if (sizeY == 0) {
+            sizeY = 1;
+        }
+        double offsetX = 0;
+        double offsetY = 0;
+
+        switch (frame.rotation) {
+            case 1:
+                sizeX = frame.sizeY;
+                sizeY = -frame.sizeX;
+                if (frame.posY == 0) {
+                    offsetY += 1;
+                } else if (frame.posY == 2) {
+                    offsetY -= 1;
+                }
+                break;
+            case 2:
+                sizeX = -frame.sizeX;
+                sizeY = -frame.sizeY;
+                if (frame.posX == 0) {
+                    offsetX += 1;
+                } else if (frame.posX == 2) {
+                    offsetX -= 1;
+                }
+                if (frame.posY == 0) {
+                    offsetY += 1;
+                } else if (frame.posY == 2) {
+                    offsetY -= 1;
+                }
+                break;
+            case 3:
+                sizeX = -frame.sizeY;
+                sizeY = frame.sizeX;
+                if (frame.posX == 0) {
+                    offsetX += 1;
+                } else if (frame.posX == 2) {
+                    offsetX -= 1;
+                }
+                break;
+        }
+
+        if (frame.posX == 1) {
+            offsetX += (-sizeX + 1) / 2D;
+        } else if (frame.posX == 2) {
+            offsetX += -sizeX + 1;
+        }
+
+        if (frame.posY == 1) {
+            offsetY += (-sizeY + 1) / 2D;
+        } else if (frame.posY == 2) {
+            offsetY += -sizeY + 1;
+        }
+
+        EnumFacing direction = EnumFacing.getFront(meta);
+        if (direction == EnumFacing.UP) {
+            cube.minZ -= sizeX - 1;
+            cube.minY -= sizeY - 1;
+
+            cube.minZ -= offsetX;
+            cube.maxZ -= offsetX;
+            cube.minY -= offsetY;
+            cube.maxY -= offsetY;
+        } else {
+            cube.maxZ += sizeX - 1;
+            cube.maxY += sizeY - 1;
+
+            cube.minZ += offsetX;
+            cube.maxZ += offsetX;
+            cube.minY += offsetY;
+            cube.maxY += offsetY;
+        }
+
+        cube = new CubeObject(Math.min(cube.minX, cube.maxX), Math.min(cube.minY, cube.maxY), Math.min(cube.minZ, cube.maxZ),
+                Math.max(cube.minX, cube.maxX), Math.max(cube.minY, cube.maxY), Math.max(cube.minZ, cube.maxZ));
+
+        return CubeObject.rotateCube(cube, direction).getAxis();
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public AxisAlignedBB getRenderBoundingBox() {
+        return getBoundingBox(this, getBlockMetadata()).offset(pos);
+    }
+
+    public int renderDistance = 512;
+
+    public String url = "";
+    public float sizeX = 1F;
+    public float sizeY = 1F;
+
+    public boolean flippedX;
+    public boolean flippedY;
+
+    /**
+     * -90 to 90
+     **/
+    public float rotationX;
+    /**
+     * -90 to 90
+     **/
+    public float rotationY;
+
+    /**
+     * 0-3 all directions
+     **/
+    public byte rotation = 0;
+
+    /**
+     * 0: normal,1: center, 2: -normal
+     **/
+    public byte posX = 0;
+    /**
+     * 0: normal,1: center, 2: -normal
+     **/
+    public byte posY = 0;
+
+    public boolean visibleFrame = true;
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        nbt = super.writeToNBT(nbt);
+        nbt.setString("url", url);
+        nbt.setFloat("sizeX", sizeX);
+        nbt.setFloat("sizeY", sizeY);
+        nbt.setInteger("render", renderDistance);
+        nbt.setByte("offsetX", posX);
+        nbt.setByte("offsetY", posY);
+        nbt.setByte("rotation", rotation);
+        nbt.setBoolean("visibleFrame", visibleFrame);
+        nbt.setBoolean("flippedX", flippedX);
+        nbt.setBoolean("flippedY", flippedY);
+        nbt.setFloat("rotX", rotationX);
+        nbt.setFloat("rotY", rotationY);
+        return nbt;
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound nbt) {
+        super.readFromNBT(nbt);
+        url = nbt.getString("url");
+        sizeX = nbt.getFloat("sizeX");
+        sizeY = nbt.getFloat("sizeY");
+        renderDistance = nbt.getInteger("render");
+        posX = nbt.getByte("offsetX");
+        posY = nbt.getByte("offsetY");
+        rotation = nbt.getByte("rotation");
+        visibleFrame = nbt.getBoolean("visibleFrame");
+        flippedX = nbt.getBoolean("flippedX");
+        flippedY = nbt.getBoolean("flippedY");
+        rotationX = nbt.getFloat("rotX");
+        rotationY = nbt.getFloat("rotY");
+    }
+
+    @Override
+    public void getDescriptionNBT(NBTTagCompound nbt) {
+        super.getDescriptionNBT(nbt);
+        nbt.setString("url", url);
+        nbt.setFloat("sizeX", sizeX);
+        nbt.setFloat("sizeY", sizeY);
+        nbt.setInteger("render", renderDistance);
+        nbt.setByte("offsetX", posX);
+        nbt.setByte("offsetY", posY);
+        nbt.setByte("rotation", rotation);
+        nbt.setBoolean("visibleFrame", visibleFrame);
+        nbt.setBoolean("flippedX", flippedX);
+        nbt.setBoolean("flippedY", flippedY);
+        nbt.setFloat("rotX", rotationX);
+        nbt.setFloat("rotY", rotationY);
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void receiveUpdatePacket(NBTTagCompound nbt) {
+        super.receiveUpdatePacket(nbt);
+        url = nbt.getString("url");
+        sizeX = nbt.getFloat("sizeX");
+        sizeY = nbt.getFloat("sizeY");
+        renderDistance = nbt.getInteger("render");
+        posX = nbt.getByte("offsetX");
+        posY = nbt.getByte("offsetY");
+        rotation = nbt.getByte("rotation");
+        visibleFrame = nbt.getBoolean("visibleFrame");
+        flippedX = nbt.getBoolean("flippedX");
+        flippedY = nbt.getBoolean("flippedY");
+        rotationX = nbt.getFloat("rotX");
+        rotationY = nbt.getFloat("rotY");
+        initClient();
+        updateRender();
+    }
 }

--- a/src/main/java/com/creativemd/opf/block/TileEntityPicFrame.java
+++ b/src/main/java/com/creativemd/opf/block/TileEntityPicFrame.java
@@ -13,271 +13,280 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class TileEntityPicFrame extends TileEntityCreative {
 
-    public TileEntityPicFrame() {
-        if (FMLCommonHandler.instance().getSide().isClient()) {
-            initClient();
-        }
-    }
+	public TileEntityPicFrame() {
+		if (FMLCommonHandler.instance().getSide().isClient()) {
+			initClient();
+		}
+	}
 
-    @SideOnly(Side.CLIENT)
-    public DownloadThread downloader;
+	@SideOnly(Side.CLIENT)
+	public DownloadThread downloader;
 
-    @SideOnly(Side.CLIENT)
-    public PictureTexture texture;
+	@SideOnly(Side.CLIENT)
+	public PictureTexture texture;
 
-    @SideOnly(Side.CLIENT)
-    public boolean failed;
+	@SideOnly(Side.CLIENT)
+	public boolean failed;
 
-    @SideOnly(Side.CLIENT)
-    public void initClient() {
-        texture = null;
-        failed = false;
-    }
+	@SideOnly(Side.CLIENT)
+	public void initClient() {
+		texture = null;
+		failed = false;
+	}
 
-    @SideOnly(Side.CLIENT)
-    public boolean shouldLoadTexture() {
-        return !isTextureLoaded() && !failed;
-    }
+	@SideOnly(Side.CLIENT)
+	public boolean shouldLoadTexture() {
+		return !isTextureLoaded() && !failed;
+	}
 
-    @SideOnly(Side.CLIENT)
-    public void loadTexture() {
-        if (shouldLoadTexture()) {
-            if (downloader == null && DownloadThread.activeDownloads < DownloadThread.MAXIMUM_ACTIVE_DOWNLOADS) {
-                PictureTexture loadedTexture = DownloadThread.loadedImages.get(url);
+	@SideOnly(Side.CLIENT)
+	public void loadTexture() {
+		if (shouldLoadTexture()) {
+			if (downloader == null && DownloadThread.activeDownloads < DownloadThread.MAXIMUM_ACTIVE_DOWNLOADS) {
+				PictureTexture loadedTexture = DownloadThread.loadedImages.get(url);
 
-                if (loadedTexture == null) {
-                    if (!DownloadThread.loadingImages.contains(url)) {
-                        synchronized (DownloadThread.LOCK) {
-                            DownloadThread.loadingImages.add(url);
-                        }
-                        downloader = new DownloadThread(url);
-                    }
-                } else {
-                    texture = loadedTexture;
-                }
-            }
-            if (downloader != null && downloader.hasFinished()) {
-                if (downloader.hasFailed()) {
-                    failed = true;
-                } else {
-                    texture = DownloadThread.loadImage(downloader);
-                }
-                synchronized (DownloadThread.LOCK) {
-                    DownloadThread.loadingImages.remove(url);
-                }
-                downloader = null;
-            }
-        }
-    }
+				if (loadedTexture == null) {
+					if (!DownloadThread.loadingImages.contains(url)) {
+						synchronized (DownloadThread.LOCK) {
+							DownloadThread.loadingImages.add(url);
+						}
+						downloader = new DownloadThread(url);
+					}
+				}
+				else {
+					texture = loadedTexture;
+				}
+			}
+			if (downloader != null && downloader.hasFinished()) {
+				if (downloader.hasFailed()) {
+					failed = true;
+				}
+				else {
+					texture = DownloadThread.loadImage(downloader);
+				}
+				synchronized (DownloadThread.LOCK) {
+					DownloadThread.loadingImages.remove(url);
+				}
+				downloader = null;
+			}
+		}
+	}
 
-    @SideOnly(Side.CLIENT)
-    public boolean isTextureLoaded() {
-        return texture != null;
-    }
+	@SideOnly(Side.CLIENT)
+	public boolean isTextureLoaded() {
+		return texture != null;
+	}
 
-    @Override
-    @SideOnly(Side.CLIENT)
-    public double getMaxRenderDistanceSquared() {
-        return Math.pow(renderDistance, 2);
-    }
+	@Override
+	@SideOnly(Side.CLIENT)
+	public double getMaxRenderDistanceSquared() {
+		return Math.pow(renderDistance, 2);
+	}
 
-    public static AxisAlignedBB getBoundingBox(TileEntityPicFrame frame, int meta) {
-        /*AxisAlignedBB bb = INFINITE_EXTENT_AABB;
+	public static AxisAlignedBB getBoundingBox(TileEntityPicFrame frame, int meta) {
+		/*AxisAlignedBB bb = INFINITE_EXTENT_AABB;
         return bb;*/
-        CubeObject cube = new CubeObject(0, 0, 0, 0.05F, 1, 1);
+		CubeObject cube = new CubeObject(0, 0, 0, 0.05F, 1, 1);
 
-        float sizeX = frame.sizeX;
-        if (sizeX == 0) {
-            sizeX = 1;
-        }
-        float sizeY = frame.sizeY;
-        if (sizeY == 0) {
-            sizeY = 1;
-        }
-        double offsetX = 0;
-        double offsetY = 0;
+		float sizeX = frame.sizeX;
+		if (sizeX == 0) {
+			sizeX = 1;
+		}
+		float sizeY = frame.sizeY;
+		if (sizeY == 0) {
+			sizeY = 1;
+		}
+		double offsetX = 0;
+		double offsetY = 0;
 
-        switch (frame.rotation) {
-            case 1:
-                sizeX = frame.sizeY;
-                sizeY = -frame.sizeX;
-                if (frame.posY == 0) {
-                    offsetY += 1;
-                } else if (frame.posY == 2) {
-                    offsetY -= 1;
-                }
-                break;
-            case 2:
-                sizeX = -frame.sizeX;
-                sizeY = -frame.sizeY;
-                if (frame.posX == 0) {
-                    offsetX += 1;
-                } else if (frame.posX == 2) {
-                    offsetX -= 1;
-                }
-                if (frame.posY == 0) {
-                    offsetY += 1;
-                } else if (frame.posY == 2) {
-                    offsetY -= 1;
-                }
-                break;
-            case 3:
-                sizeX = -frame.sizeY;
-                sizeY = frame.sizeX;
-                if (frame.posX == 0) {
-                    offsetX += 1;
-                } else if (frame.posX == 2) {
-                    offsetX -= 1;
-                }
-                break;
-        }
+		switch (frame.rotation) {
+			case 1:
+				sizeX = frame.sizeY;
+				sizeY = -frame.sizeX;
+				if (frame.posY == 0) {
+					offsetY += 1;
+				}
+				else if (frame.posY == 2) {
+					offsetY -= 1;
+				}
+				break;
+			case 2:
+				sizeX = -frame.sizeX;
+				sizeY = -frame.sizeY;
+				if (frame.posX == 0) {
+					offsetX += 1;
+				}
+				else if (frame.posX == 2) {
+					offsetX -= 1;
+				}
+				if (frame.posY == 0) {
+					offsetY += 1;
+				}
+				else if (frame.posY == 2) {
+					offsetY -= 1;
+				}
+				break;
+			case 3:
+				sizeX = -frame.sizeY;
+				sizeY = frame.sizeX;
+				if (frame.posX == 0) {
+					offsetX += 1;
+				}
+				else if (frame.posX == 2) {
+					offsetX -= 1;
+				}
+				break;
+		}
 
-        if (frame.posX == 1) {
-            offsetX += (-sizeX + 1) / 2D;
-        } else if (frame.posX == 2) {
-            offsetX += -sizeX + 1;
-        }
+		if (frame.posX == 1) {
+			offsetX += (-sizeX + 1) / 2D;
+		}
+		else if (frame.posX == 2) {
+			offsetX += -sizeX + 1;
+		}
 
-        if (frame.posY == 1) {
-            offsetY += (-sizeY + 1) / 2D;
-        } else if (frame.posY == 2) {
-            offsetY += -sizeY + 1;
-        }
+		if (frame.posY == 1) {
+			offsetY += (-sizeY + 1) / 2D;
+		}
+		else if (frame.posY == 2) {
+			offsetY += -sizeY + 1;
+		}
 
-        EnumFacing direction = EnumFacing.getFront(meta);
-        if (direction == EnumFacing.UP) {
-            cube.minZ -= sizeX - 1;
-            cube.minY -= sizeY - 1;
+		EnumFacing direction = EnumFacing.getFront(meta);
+		if (direction == EnumFacing.UP) {
+			cube.minZ -= sizeX - 1;
+			cube.minY -= sizeY - 1;
 
-            cube.minZ -= offsetX;
-            cube.maxZ -= offsetX;
-            cube.minY -= offsetY;
-            cube.maxY -= offsetY;
-        } else {
-            cube.maxZ += sizeX - 1;
-            cube.maxY += sizeY - 1;
+			cube.minZ -= offsetX;
+			cube.maxZ -= offsetX;
+			cube.minY -= offsetY;
+			cube.maxY -= offsetY;
+		}
+		else {
+			cube.maxZ += sizeX - 1;
+			cube.maxY += sizeY - 1;
 
-            cube.minZ += offsetX;
-            cube.maxZ += offsetX;
-            cube.minY += offsetY;
-            cube.maxY += offsetY;
-        }
+			cube.minZ += offsetX;
+			cube.maxZ += offsetX;
+			cube.minY += offsetY;
+			cube.maxY += offsetY;
+		}
 
-        cube = new CubeObject(Math.min(cube.minX, cube.maxX), Math.min(cube.minY, cube.maxY), Math.min(cube.minZ, cube.maxZ),
-                Math.max(cube.minX, cube.maxX), Math.max(cube.minY, cube.maxY), Math.max(cube.minZ, cube.maxZ));
+		cube = new CubeObject(Math.min(cube.minX, cube.maxX), Math.min(cube.minY, cube.maxY), Math.min(cube.minZ, cube.maxZ),
+				Math.max(cube.minX, cube.maxX), Math.max(cube.minY, cube.maxY), Math.max(cube.minZ, cube.maxZ));
 
-        return CubeObject.rotateCube(cube, direction).getAxis();
-    }
+		return CubeObject.rotateCube(cube, direction).getAxis();
+	}
 
-    @Override
-    @SideOnly(Side.CLIENT)
-    public AxisAlignedBB getRenderBoundingBox() {
-        return getBoundingBox(this, getBlockMetadata()).offset(pos);
-    }
+	@Override
+	@SideOnly(Side.CLIENT)
+	public AxisAlignedBB getRenderBoundingBox() {
+		return getBoundingBox(this, getBlockMetadata()).offset(pos);
+	}
 
-    public int renderDistance = 512;
+	public int renderDistance = 512;
 
-    public String url = "";
-    public float sizeX = 1F;
-    public float sizeY = 1F;
+	public String url = "";
+	public float sizeX = 1F;
+	public float sizeY = 1F;
 
-    public boolean flippedX;
-    public boolean flippedY;
+	public boolean flippedX;
+	public boolean flippedY;
 
-    /**
-     * -90 to 90
-     **/
-    public float rotationX;
-    /**
-     * -90 to 90
-     **/
-    public float rotationY;
+	/**
+	 * -90 to 90
+	 **/
+	public float rotationX;
+	/**
+	 * -90 to 90
+	 **/
+	public float rotationY;
 
-    /**
-     * 0-3 all directions
-     **/
-    public byte rotation = 0;
+	/**
+	 * 0-3 all directions
+	 **/
+	public byte rotation = 0;
 
-    /**
-     * 0: normal,1: center, 2: -normal
-     **/
-    public byte posX = 0;
-    /**
-     * 0: normal,1: center, 2: -normal
-     **/
-    public byte posY = 0;
+	/**
+	 * 0: normal,1: center, 2: -normal
+	 **/
+	public byte posX = 0;
+	/**
+	 * 0: normal,1: center, 2: -normal
+	 **/
+	public byte posY = 0;
 
-    public boolean visibleFrame = true;
+	public boolean visibleFrame = true;
 
-    @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
-        nbt = super.writeToNBT(nbt);
-        nbt.setString("url", url);
-        nbt.setFloat("sizeX", sizeX);
-        nbt.setFloat("sizeY", sizeY);
-        nbt.setInteger("render", renderDistance);
-        nbt.setByte("offsetX", posX);
-        nbt.setByte("offsetY", posY);
-        nbt.setByte("rotation", rotation);
-        nbt.setBoolean("visibleFrame", visibleFrame);
-        nbt.setBoolean("flippedX", flippedX);
-        nbt.setBoolean("flippedY", flippedY);
-        nbt.setFloat("rotX", rotationX);
-        nbt.setFloat("rotY", rotationY);
-        return nbt;
-    }
+	@Override
+	public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+		nbt = super.writeToNBT(nbt);
+		nbt.setString("url", url);
+		nbt.setFloat("sizeX", sizeX);
+		nbt.setFloat("sizeY", sizeY);
+		nbt.setInteger("render", renderDistance);
+		nbt.setByte("offsetX", posX);
+		nbt.setByte("offsetY", posY);
+		nbt.setByte("rotation", rotation);
+		nbt.setBoolean("visibleFrame", visibleFrame);
+		nbt.setBoolean("flippedX", flippedX);
+		nbt.setBoolean("flippedY", flippedY);
+		nbt.setFloat("rotX", rotationX);
+		nbt.setFloat("rotY", rotationY);
+		return nbt;
+	}
 
-    @Override
-    public void readFromNBT(NBTTagCompound nbt) {
-        super.readFromNBT(nbt);
-        url = nbt.getString("url");
-        sizeX = nbt.getFloat("sizeX");
-        sizeY = nbt.getFloat("sizeY");
-        renderDistance = nbt.getInteger("render");
-        posX = nbt.getByte("offsetX");
-        posY = nbt.getByte("offsetY");
-        rotation = nbt.getByte("rotation");
-        visibleFrame = nbt.getBoolean("visibleFrame");
-        flippedX = nbt.getBoolean("flippedX");
-        flippedY = nbt.getBoolean("flippedY");
-        rotationX = nbt.getFloat("rotX");
-        rotationY = nbt.getFloat("rotY");
-    }
+	@Override
+	public void readFromNBT(NBTTagCompound nbt) {
+		super.readFromNBT(nbt);
+		url = nbt.getString("url");
+		sizeX = nbt.getFloat("sizeX");
+		sizeY = nbt.getFloat("sizeY");
+		renderDistance = nbt.getInteger("render");
+		posX = nbt.getByte("offsetX");
+		posY = nbt.getByte("offsetY");
+		rotation = nbt.getByte("rotation");
+		visibleFrame = nbt.getBoolean("visibleFrame");
+		flippedX = nbt.getBoolean("flippedX");
+		flippedY = nbt.getBoolean("flippedY");
+		rotationX = nbt.getFloat("rotX");
+		rotationY = nbt.getFloat("rotY");
+	}
 
-    @Override
-    public void getDescriptionNBT(NBTTagCompound nbt) {
-        super.getDescriptionNBT(nbt);
-        nbt.setString("url", url);
-        nbt.setFloat("sizeX", sizeX);
-        nbt.setFloat("sizeY", sizeY);
-        nbt.setInteger("render", renderDistance);
-        nbt.setByte("offsetX", posX);
-        nbt.setByte("offsetY", posY);
-        nbt.setByte("rotation", rotation);
-        nbt.setBoolean("visibleFrame", visibleFrame);
-        nbt.setBoolean("flippedX", flippedX);
-        nbt.setBoolean("flippedY", flippedY);
-        nbt.setFloat("rotX", rotationX);
-        nbt.setFloat("rotY", rotationY);
-    }
+	@Override
+	public void getDescriptionNBT(NBTTagCompound nbt) {
+		super.getDescriptionNBT(nbt);
+		nbt.setString("url", url);
+		nbt.setFloat("sizeX", sizeX);
+		nbt.setFloat("sizeY", sizeY);
+		nbt.setInteger("render", renderDistance);
+		nbt.setByte("offsetX", posX);
+		nbt.setByte("offsetY", posY);
+		nbt.setByte("rotation", rotation);
+		nbt.setBoolean("visibleFrame", visibleFrame);
+		nbt.setBoolean("flippedX", flippedX);
+		nbt.setBoolean("flippedY", flippedY);
+		nbt.setFloat("rotX", rotationX);
+		nbt.setFloat("rotY", rotationY);
+	}
 
-    @Override
-    @SideOnly(Side.CLIENT)
-    public void receiveUpdatePacket(NBTTagCompound nbt) {
-        super.receiveUpdatePacket(nbt);
-        url = nbt.getString("url");
-        sizeX = nbt.getFloat("sizeX");
-        sizeY = nbt.getFloat("sizeY");
-        renderDistance = nbt.getInteger("render");
-        posX = nbt.getByte("offsetX");
-        posY = nbt.getByte("offsetY");
-        rotation = nbt.getByte("rotation");
-        visibleFrame = nbt.getBoolean("visibleFrame");
-        flippedX = nbt.getBoolean("flippedX");
-        flippedY = nbt.getBoolean("flippedY");
-        rotationX = nbt.getFloat("rotX");
-        rotationY = nbt.getFloat("rotY");
-        initClient();
-        updateRender();
-    }
+	@Override
+	@SideOnly(Side.CLIENT)
+	public void receiveUpdatePacket(NBTTagCompound nbt) {
+		super.receiveUpdatePacket(nbt);
+		url = nbt.getString("url");
+		sizeX = nbt.getFloat("sizeX");
+		sizeY = nbt.getFloat("sizeY");
+		renderDistance = nbt.getInteger("render");
+		posX = nbt.getByte("offsetX");
+		posY = nbt.getByte("offsetY");
+		rotation = nbt.getByte("rotation");
+		visibleFrame = nbt.getBoolean("visibleFrame");
+		flippedX = nbt.getBoolean("flippedX");
+		flippedY = nbt.getBoolean("flippedY");
+		rotationX = nbt.getFloat("rotX");
+		rotationY = nbt.getFloat("rotY");
+		initClient();
+		updateRender();
+	}
 }

--- a/src/main/java/com/creativemd/opf/block/TileEntityPicFrame.java
+++ b/src/main/java/com/creativemd/opf/block/TileEntityPicFrame.java
@@ -6,12 +6,13 @@ import com.creativemd.opf.client.DownloadThread;
 import com.creativemd.opf.client.PictureTexture;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ITickable;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class TileEntityPicFrame extends TileEntityCreative {
+public class TileEntityPicFrame extends TileEntityCreative implements ITickable {
 
 	public TileEntityPicFrame() {
 		if (FMLCommonHandler.instance().getSide().isClient()) {
@@ -288,5 +289,18 @@ public class TileEntityPicFrame extends TileEntityCreative {
 		rotationY = nbt.getFloat("rotY");
 		initClient();
 		updateRender();
+	}
+
+	@Override
+	public void update() {
+		if (world.isRemote) {
+			tickTexture();
+		}
+	}
+
+	private void tickTexture() {
+		if (texture != null) {
+			texture.tick();
+		}
 	}
 }

--- a/src/main/java/com/creativemd/opf/client/AnimatedPictureTexture.java
+++ b/src/main/java/com/creativemd/opf/client/AnimatedPictureTexture.java
@@ -3,36 +3,46 @@ package com.creativemd.opf.client;
 import com.porpit.lib.GifDecoder;
 
 public class AnimatedPictureTexture extends PictureTexture {
-	
-	private final int[] textureIDs;
-	private final long[] delay;
-	private final long duration;
-	
-	public AnimatedPictureTexture(GifDecoder decoder) {
-		super((int) decoder.getFrameSize().getWidth(), (int) decoder.getFrameSize().getHeight());
-		textureIDs = new int[decoder.getFrameCount()];
-		delay = new long[decoder.getFrameCount()];
-		long time = 0;
-		for (int i = 0; i < textureIDs.length; i++) {
-			textureIDs[i] = DownloadThread.loadTexture(decoder.getFrame(i));
-			delay[i] = time;
-			time += decoder.getDelay(i);
-		}
-		duration = time;
-	}
 
-	@Override
-	public int getTextureID() {
-		long time = duration > 0 ? System.currentTimeMillis() % duration : 0;
-		int index = 0;
-		for (int i = 0; i < delay.length; i++) {
-			if(delay[i] >= time)
-			{
-				index = i;
-				break;
-			}
-		}
-		return textureIDs[index];
-	}
+    private final int[] textureIDs;
+    private final long[] delay;
+    private final long duration;
 
+    private int completedFrames;
+    private GifDecoder gif;
+
+    public AnimatedPictureTexture(GifDecoder decoder) {
+        super((int) decoder.getFrameSize().getWidth(), (int) decoder.getFrameSize().getHeight());
+        gif = decoder;
+        textureIDs = new int[decoder.getFrameCount()];
+        delay = new long[decoder.getFrameCount()];
+        long time = 0;
+        for (int i = 0; i < textureIDs.length; i++) {
+            textureIDs[i] = -1;
+            delay[i] = time;
+            time += decoder.getDelay(i);
+        }
+        duration = time;
+    }
+
+    @Override
+    public int getTextureID() {
+        long time = duration > 0 ? System.currentTimeMillis() % duration : 0;
+        int index = 0;
+        for (int i = 0; i < delay.length; i++) {
+            if (delay[i] >= time) {
+                index = i;
+                break;
+            }
+        }
+        int id = textureIDs[index];
+        if (id == -1) {
+            id = DownloadThread.loadTexture(gif.getFrame(index));
+            textureIDs[index] = id;
+            if (++completedFrames >= gif.getFrameCount()) {
+                gif = null;
+            }
+        }
+        return id;
+    }
 }

--- a/src/main/java/com/creativemd/opf/client/AnimatedPictureTexture.java
+++ b/src/main/java/com/creativemd/opf/client/AnimatedPictureTexture.java
@@ -2,43 +2,43 @@ package com.creativemd.opf.client;
 
 public class AnimatedPictureTexture extends PictureTexture {
 
-    private final int[] textureIDs;
-    private final long[] delay;
-    private final long duration;
+	private final int[] textureIDs;
+	private final long[] delay;
+	private final long duration;
 
-    private int completedFrames;
-    private ProcessedImageData imageData;
+	private int completedFrames;
+	private ProcessedImageData imageData;
 
-    public AnimatedPictureTexture(ProcessedImageData image) {
-        super(image.getWidth(), image.getHeight());
-        imageData = image;
-        textureIDs = new int[image.getFrameCount()];
-        delay = image.getDelay();
-        duration = image.getDuration();
-        for (int i = 0; i < textureIDs.length; i++) {
-            textureIDs[i] = -1;
-        }
-    }
+	public AnimatedPictureTexture(ProcessedImageData image) {
+		super(image.getWidth(), image.getHeight());
+		imageData = image;
+		textureIDs = new int[image.getFrameCount()];
+		delay = image.getDelay();
+		duration = image.getDuration();
+		for (int i = 0; i < textureIDs.length; i++) {
+			textureIDs[i] = -1;
+		}
+	}
 
-    @Override
-    public int getTextureID() {
-        long time = duration > 0 ? System.currentTimeMillis() % duration : 0;
-        int index = 0;
-        for (int i = 0; i < delay.length; i++) {
-            if (delay[i] >= time) {
-                index = i;
-                break;
-            }
-        }
-        int id = textureIDs[index];
-        if (id == -1) {
-            id = imageData.uploadFrame(index);
-            textureIDs[index] = id;
-            if (++completedFrames >= imageData.getFrameCount()) {
-                //Unload imageData after all frames have been loaded
-                imageData = null;
-            }
-        }
-        return id;
-    }
+	@Override
+	public int getTextureID() {
+		long time = duration > 0 ? System.currentTimeMillis() % duration : 0;
+		int index = 0;
+		for (int i = 0; i < delay.length; i++) {
+			if (delay[i] >= time) {
+				index = i;
+				break;
+			}
+		}
+		int id = textureIDs[index];
+		if (id == -1) {
+			id = imageData.uploadFrame(index);
+			textureIDs[index] = id;
+			if (++completedFrames >= imageData.getFrameCount()) {
+				//Unload imageData after all frames have been loaded
+				imageData = null;
+			}
+		}
+		return id;
+	}
 }

--- a/src/main/java/com/creativemd/opf/client/AnimatedPictureTexture.java
+++ b/src/main/java/com/creativemd/opf/client/AnimatedPictureTexture.java
@@ -21,6 +21,23 @@ public class AnimatedPictureTexture extends PictureTexture {
 	}
 
 	@Override
+	public void tick() {
+		if (imageData != null) {
+			//Upload as many frames as possible in 10 ms
+			long startTime = System.currentTimeMillis();
+			int index = 0;
+			while (completedFrames < textureIDs.length && index < textureIDs.length && System.currentTimeMillis() - startTime < 10) {
+				while (textureIDs[index] != -1 && index < textureIDs.length - 1) {
+					index++;
+				}
+				if (textureIDs[index] == -1) {
+					textureIDs[index] = uploadFrame(index);
+				}
+			}
+		}
+	}
+
+	@Override
 	public int getTextureID() {
 		long time = duration > 0 ? System.currentTimeMillis() % duration : 0;
 		int index = 0;
@@ -30,14 +47,16 @@ public class AnimatedPictureTexture extends PictureTexture {
 				break;
 			}
 		}
-		int id = textureIDs[index];
-		if (id == -1) {
-			id = imageData.uploadFrame(index);
-			textureIDs[index] = id;
-			if (++completedFrames >= imageData.getFrameCount()) {
-				//Unload imageData after all frames have been loaded
-				imageData = null;
-			}
+		return textureIDs[index];
+	}
+
+	private int uploadFrame(int index) {
+		int id;
+		id = imageData.uploadFrame(index);
+		textureIDs[index] = id;
+		if (++completedFrames >= imageData.getFrameCount()) {
+			//Unload imageData after all frames have been loaded
+			imageData = null;
 		}
 		return id;
 	}

--- a/src/main/java/com/creativemd/opf/client/AnimatedPictureTexture.java
+++ b/src/main/java/com/creativemd/opf/client/AnimatedPictureTexture.java
@@ -1,7 +1,5 @@
 package com.creativemd.opf.client;
 
-import com.porpit.lib.GifDecoder;
-
 public class AnimatedPictureTexture extends PictureTexture {
 
     private final int[] textureIDs;
@@ -9,20 +7,17 @@ public class AnimatedPictureTexture extends PictureTexture {
     private final long duration;
 
     private int completedFrames;
-    private GifDecoder gif;
+    private ProcessedImageData imageData;
 
-    public AnimatedPictureTexture(GifDecoder decoder) {
-        super((int) decoder.getFrameSize().getWidth(), (int) decoder.getFrameSize().getHeight());
-        gif = decoder;
-        textureIDs = new int[decoder.getFrameCount()];
-        delay = new long[decoder.getFrameCount()];
-        long time = 0;
+    public AnimatedPictureTexture(ProcessedImageData image) {
+        super(image.getWidth(), image.getHeight());
+        imageData = image;
+        textureIDs = new int[image.getFrameCount()];
+        delay = image.getDelay();
+        duration = image.getDuration();
         for (int i = 0; i < textureIDs.length; i++) {
             textureIDs[i] = -1;
-            delay[i] = time;
-            time += decoder.getDelay(i);
         }
-        duration = time;
     }
 
     @Override
@@ -37,10 +32,11 @@ public class AnimatedPictureTexture extends PictureTexture {
         }
         int id = textureIDs[index];
         if (id == -1) {
-            id = DownloadThread.loadTexture(gif.getFrame(index));
+            id = imageData.uploadFrame(index);
             textureIDs[index] = id;
-            if (++completedFrames >= gif.getFrameCount()) {
-                gif = null;
+            if (++completedFrames >= imageData.getFrameCount()) {
+                //Unload imageData after all frames have been loaded
+                imageData = null;
             }
         }
         return id;

--- a/src/main/java/com/creativemd/opf/client/DownloadThread.java
+++ b/src/main/java/com/creativemd/opf/client/DownloadThread.java
@@ -165,8 +165,6 @@ public class DownloadThread extends Thread {
     private static final int BYTES_PER_PIXEL = 4;
 
     public static int loadTexture(BufferedImage image) {
-        long time = System.currentTimeMillis();
-
         int[] pixels = new int[image.getWidth() * image.getHeight()];
         image.getRGB(0, 0, image.getWidth(), image.getHeight(), pixels, 0, image.getWidth());
 
@@ -197,8 +195,6 @@ public class DownloadThread extends Thread {
 
         //Send texel data to OpenGL
         GL11.glTexImage2D(GL11.GL_TEXTURE_2D, 0, GL11.GL_RGBA8, image.getWidth(), image.getHeight(), 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, buffer);
-
-        System.out.println("Took " + (System.currentTimeMillis() - time) + "ms to upload image");
 
         //Return the texture ID so we can bind it later again
         return textureID;

--- a/src/main/java/com/creativemd/opf/client/DownloadThread.java
+++ b/src/main/java/com/creativemd/opf/client/DownloadThread.java
@@ -1,206 +1,176 @@
 package com.creativemd.opf.client;
 
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.Authenticator;
-import java.net.PasswordAuthentication;
-import java.net.URL;
-import java.net.URLConnection;
-import java.nio.ByteBuffer;
-import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
+import com.porpit.lib.GifDecoder;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import org.apache.commons.io.IOUtils;
+import org.lwjgl.BufferUtils;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
-import javax.vecmath.Vector2f;
-
-import org.lwjgl.BufferUtils;
-import org.lwjgl.opengl.GL11;
-import org.lwjgl.opengl.GL12;
-
-import com.porpit.lib.GifDecoder;
-
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 
 @SideOnly(Side.CLIENT)
 public class DownloadThread extends Thread {
-	
-	public static HashMap<String, PictureTexture> loadedImages = new HashMap<String, PictureTexture>();
-	
-	public static ArrayList<String> loadingImages = new ArrayList<String>();
-	
-	private String url;
-	
-	private float progress = 0F;
-	
-	private InputStream loadedStream = null; 
-	
-	public DownloadThread(String url) {
-		this.url = url;
-		start();
-	}
-	
-	public boolean hasFinished()
-	{
-		return progress == 1F;
-	}
-	
-	public boolean hasFailed()
-	{
-		return hasFinished() && loadedStream == null;
-	}
-	
-	public InputStream getDownloadedImage()
-	{
-		return loadedStream;
-	}
-	
-	public float getProgress()
-	{
-		return progress;
-	}
-	
-	@Override
-	public void run()
-	{
-		try{	        
-			URLConnection con = new URL(url).openConnection();
-			con.addRequestProperty("User-Agent", "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)");
-			loadedStream = (InputStream) con.getInputStream();
-		} catch (Exception e) {
-			loadedStream = null;
-			e.printStackTrace();
-		}
-		
-		
-		
-		progress = 1F;
-	}
-	
-	public static String readType(InputStream input) throws IOException
-	{
-	    ImageInputStream stream = ImageIO.createImageInputStream(input);
 
-	    Iterator iter = ImageIO.getImageReaders(stream);
-	    if (!iter.hasNext()) {
-	        return "";
-	    }
-	    ImageReader reader = (ImageReader) iter.next();
-	    ImageReadParam param = reader.getDefaultReadParam();
-	    reader.setInput(stream, true, true);
-	    BufferedImage bi;
-	    try {
-	        bi = reader.read(0, param);
-	    } catch (IOException e) {
-	        e.printStackTrace();
-	    } finally {
-	        reader.dispose();
-	        try {
-	            stream.close();
-	        } catch (IOException e) {
-	            e.printStackTrace();
-	        }
-	    }
-	    input.reset();
-	    return reader.getFormatName();
-	}
-	
-	public static PictureTexture loadImage(DownloadThread thread)
-	{
-		PictureTexture texture = null;
-		if(!thread.hasFailed())
-		{
-			InputStream stream = thread.getDownloadedImage();
-			ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			
-			byte[] buffer = new byte[1024];
-			int len;
-			try {
-				while ((len = stream.read(buffer)) > -1 ) {
-				    baos.write(buffer, 0, len);
-				}
-			} catch (IOException e2) {
-				e2.printStackTrace();
-			}
-			try {
-				baos.flush();
-			} catch (IOException e1) {
-				e1.printStackTrace();
-			}
-			
-			InputStream is1 = new ByteArrayInputStream(baos.toByteArray()); 
-			InputStream is2 = new ByteArrayInputStream(baos.toByteArray()); 
-			try {
-				if(readType(is1).equals("gif"))
-				{
-					GifDecoder gif = new GifDecoder();
-					if(gif.read(is2) == GifDecoder.STATUS_OK)
-						texture = new AnimatedPictureTexture(gif);
-				}else{
-					BufferedImage image = ImageIO.read(is2);
-					if(image != null)
-						texture = new OrdinaryTexture(image);
-				}
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-		}
-		if(texture != null)
-			loadedImages.put(thread.url, texture);
-		return texture;
-	}
-	
-	private static final int BYTES_PER_PIXEL = 4;
-	
-	public static int loadTexture(BufferedImage image)
-	{
-		int[] pixels = new int[image.getWidth() * image.getHeight()];
-		image.getRGB(0, 0, image.getWidth(), image.getHeight(), pixels, 0, image.getWidth());
-		
-		ByteBuffer buffer = BufferUtils.createByteBuffer(image.getWidth() * image.getHeight() * BYTES_PER_PIXEL); //4 for RGBA, 3 for RGB
-		
-		for(int y = 0; y < image.getHeight(); y++){
-			for(int x = 0; x < image.getWidth(); x++){
-				int pixel = pixels[y * image.getWidth() + x];
-				buffer.put((byte) ((pixel >> 16) & 0xFF));     // Red component
-				buffer.put((byte) ((pixel >> 8) & 0xFF));      // Green component
-				buffer.put((byte) (pixel & 0xFF));               // Blue component
-				buffer.put((byte) ((pixel >> 24) & 0xFF));    // Alpha component. Only for RGBA
-			}
-		}
-		
-		buffer.flip();
-		
-		int textureID = GL11.glGenTextures(); //Generate texture ID
-		GL11.glBindTexture(GL11.GL_TEXTURE_2D, textureID); //Bind texture ID
-		
-		//Setup wrap mode
-		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, GL12.GL_CLAMP_TO_EDGE);
-		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, GL12.GL_CLAMP_TO_EDGE);
-		
-		//Setup texture scaling filtering
-		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR);
-		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_LINEAR);
-		
-		//Send texel data to OpenGL
-		GL11.glTexImage2D(GL11.GL_TEXTURE_2D, 0, GL11.GL_RGBA8, image.getWidth(), image.getHeight(), 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, buffer);
-		
-		//Return the texture ID so we can bind it later again
-		return textureID;
-	}
-	
+    public static HashMap<String, PictureTexture> loadedImages = new HashMap<String, PictureTexture>();
+
+    public static ArrayList<String> loadingImages = new ArrayList<String>();
+
+    private String url;
+
+    private BufferedImage loadedImage;
+    private GifDecoder loadedGif;
+    private boolean failed;
+    private boolean complete;
+
+    public DownloadThread(String url) {
+        this.url = url;
+        setName("OpF Download Thread " + url);
+        setDaemon(true);
+        start();
+    }
+
+    public boolean hasFinished() {
+        return complete;
+    }
+
+    public boolean hasFailed() {
+        return hasFinished() && failed;
+    }
+
+    @Override
+    public void run() {
+        InputStream loadedStream = null;
+        try {
+            URLConnection con = new URL(url).openConnection();
+            con.addRequestProperty("User-Agent", "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)");
+            loadedStream = con.getInputStream();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        if (loadedStream != null) {
+            InputStream is1 = null;
+            InputStream is2 = null;
+            try {
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                byte[] buffer = IOUtils.toByteArray(loadedStream);
+                baos.write(buffer);
+                baos.flush();
+                is1 = new ByteArrayInputStream(baos.toByteArray());
+                is2 = new ByteArrayInputStream(baos.toByteArray());
+                if (readType(is1).equals("gif")) {
+                    GifDecoder gif = new GifDecoder();
+                    if (gif.read(is2) == GifDecoder.STATUS_OK) {
+                        loadedGif = gif;
+                    } else {
+                        failed = true;
+                    }
+                } else {
+                    loadedImage = ImageIO.read(is2);
+                }
+            } catch (IOException e) {
+                failed = true;
+                e.printStackTrace();
+            } finally {
+                IOUtils.closeQuietly(is1);
+                IOUtils.closeQuietly(is2);
+            }
+        } else {
+            failed = true;
+        }
+        complete = true;
+    }
+
+    public static String readType(InputStream input) throws IOException {
+        ImageInputStream stream = ImageIO.createImageInputStream(input);
+        Iterator iter = ImageIO.getImageReaders(stream);
+        if (!iter.hasNext()) {
+            return "";
+        }
+        ImageReader reader = (ImageReader) iter.next();
+        ImageReadParam param = reader.getDefaultReadParam();
+        reader.setInput(stream, true, true);
+        try {
+            reader.read(0, param);
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            reader.dispose();
+            try {
+                stream.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        input.reset();
+        return reader.getFormatName();
+    }
+
+    public static PictureTexture loadImage(DownloadThread thread) {
+        PictureTexture texture = null;
+        if (!thread.hasFailed()) {
+            if (thread.loadedGif != null) {
+                texture = new AnimatedPictureTexture(thread.loadedGif);
+            } else if (thread.loadedImage != null) {
+                texture = new OrdinaryTexture(thread.loadedImage);
+            }
+        }
+        if (texture != null) {
+            loadedImages.put(thread.url, texture);
+        }
+        return texture;
+    }
+
+    private static final int BYTES_PER_PIXEL = 4;
+
+    public static int loadTexture(BufferedImage image) {
+        int[] pixels = new int[image.getWidth() * image.getHeight()];
+        image.getRGB(0, 0, image.getWidth(), image.getHeight(), pixels, 0, image.getWidth());
+
+        ByteBuffer buffer = BufferUtils.createByteBuffer(image.getWidth() * image.getHeight() * BYTES_PER_PIXEL); //4 for RGBA, 3 for RGB
+
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                int pixel = pixels[y * image.getWidth() + x];
+                buffer.put((byte) ((pixel >> 16) & 0xFF));     // Red component
+                buffer.put((byte) ((pixel >> 8) & 0xFF));      // Green component
+                buffer.put((byte) (pixel & 0xFF));               // Blue component
+                buffer.put((byte) ((pixel >> 24) & 0xFF));    // Alpha component. Only for RGBA
+            }
+        }
+
+        buffer.flip();
+
+        int textureID = GL11.glGenTextures(); //Generate texture ID
+        GL11.glBindTexture(GL11.GL_TEXTURE_2D, textureID); //Bind texture ID
+
+        //Setup wrap mode
+        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, GL12.GL_CLAMP_TO_EDGE);
+        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, GL12.GL_CLAMP_TO_EDGE);
+
+        //Setup texture scaling filtering
+        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR);
+        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_LINEAR);
+
+        //Send texel data to OpenGL
+        GL11.glTexImage2D(GL11.GL_TEXTURE_2D, 0, GL11.GL_RGBA8, image.getWidth(), image.getHeight(), 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, buffer);
+
+        //Return the texture ID so we can bind it later again
+        return textureID;
+    }
 }

--- a/src/main/java/com/creativemd/opf/client/DownloadThread.java
+++ b/src/main/java/com/creativemd/opf/client/DownloadThread.java
@@ -32,196 +32,210 @@ import java.util.Iterator;
 
 @SideOnly(Side.CLIENT)
 public class DownloadThread extends Thread {
-    public static final Logger LOGGER = LogManager.getLogger(OPFrame.class);
+	public static final Logger LOGGER = LogManager.getLogger(OPFrame.class);
 
-    public static final TextureCache TEXTURE_CACHE = new TextureCache();
-    public static final DateFormat FORMAT = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
-    public static final Object LOCK = new Object();
-    public static final int MAXIMUM_ACTIVE_DOWNLOADS = 5;
+	public static final TextureCache TEXTURE_CACHE = new TextureCache();
+	public static final DateFormat FORMAT = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
+	public static final Object LOCK = new Object();
+	public static final int MAXIMUM_ACTIVE_DOWNLOADS = 5;
 
-    public static int activeDownloads = 0;
+	public static int activeDownloads = 0;
 
-    public static HashMap<String, PictureTexture> loadedImages = new HashMap<String, PictureTexture>();
-    public static ArrayList<String> loadingImages = new ArrayList<String>();
+	public static HashMap<String, PictureTexture> loadedImages = new HashMap<String, PictureTexture>();
+	public static ArrayList<String> loadingImages = new ArrayList<String>();
 
-    private String url;
+	private String url;
 
-    private ProcessedImageData processedImage;
-    private boolean failed;
-    private boolean complete;
+	private ProcessedImageData processedImage;
+	private boolean failed;
+	private boolean complete;
 
-    public DownloadThread(String url) {
-        this.url = url;
-        synchronized (LOCK) {
-            activeDownloads++;
-        }
-        setName("OPF Download \"" + url + "\"");
-        setDaemon(true);
-        start();
-    }
+	public DownloadThread(String url) {
+		this.url = url;
+		synchronized (LOCK) {
+			activeDownloads++;
+		}
+		setName("OPF Download \"" + url + "\"");
+		setDaemon(true);
+		start();
+	}
 
-    public boolean hasFinished() {
-        return complete;
-    }
+	public boolean hasFinished() {
+		return complete;
+	}
 
-    public boolean hasFailed() {
-        return hasFinished() && failed;
-    }
+	public boolean hasFailed() {
+		return hasFinished() && failed;
+	}
 
-    @Override
-    public void run() {
-        try {
-            byte[] data = load(url);
-            String type = readType(data);
-            ByteArrayInputStream in = null;
-            try {
-                in = new ByteArrayInputStream(data);
-                if (type.equalsIgnoreCase("gif")) {
-                    GifDecoder gif = new GifDecoder();
-                    int status = gif.read(in);
-                    if (status == GifDecoder.STATUS_OK) {
-                        processedImage = new ProcessedImageData(gif);
-                    } else {
-                        LOGGER.error("Failed to read gif: " + status);
-                    }
-                } else {
-                    try {
-                        BufferedImage image = ImageIO.read(in);
-                        if (image != null) {
-                            processedImage = new ProcessedImageData(image);
-                        }
-                    } catch (IOException e1) {
-                        LOGGER.error("Failed to parse BufferedImage from stream", e1);
-                    }
-                }
-            } finally {
-                IOUtils.closeQuietly(in);
-            }
-        } catch (IOException e) {
-            LOGGER.error("An exception occurred while loading OPFrame image", e);
-        }
-        if (processedImage == null) {
-            failed = true;
-        }
-        complete = true;
-        synchronized (LOCK) {
-            activeDownloads--;
-        }
-    }
+	@Override
+	public void run() {
+		try {
+			byte[] data = load(url);
+			String type = readType(data);
+			ByteArrayInputStream in = null;
+			try {
+				in = new ByteArrayInputStream(data);
+				if (type.equalsIgnoreCase("gif")) {
+					GifDecoder gif = new GifDecoder();
+					int status = gif.read(in);
+					if (status == GifDecoder.STATUS_OK) {
+						processedImage = new ProcessedImageData(gif);
+					}
+					else {
+						LOGGER.error("Failed to read gif: " + status);
+					}
+				}
+				else {
+					try {
+						BufferedImage image = ImageIO.read(in);
+						if (image != null) {
+							processedImage = new ProcessedImageData(image);
+						}
+					}
+					catch (IOException e1) {
+						LOGGER.error("Failed to parse BufferedImage from stream", e1);
+					}
+				}
+			}
+			finally {
+				IOUtils.closeQuietly(in);
+			}
+		}
+		catch (IOException e) {
+			LOGGER.error("An exception occurred while loading OPFrame image", e);
+		}
+		if (processedImage == null) {
+			failed = true;
+		}
+		complete = true;
+		synchronized (LOCK) {
+			activeDownloads--;
+		}
+	}
 
-    public static byte[] load(String url) throws IOException {
-        TextureCache.CacheEntry entry = TEXTURE_CACHE.getEntry(url);
-        long requestTime = System.currentTimeMillis();
-        URLConnection connection = new URL(url).openConnection();
-        connection.addRequestProperty("User-Agent", "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)");
-        int responseCode = -1;
-        if (connection instanceof HttpURLConnection) {
-            HttpURLConnection httpConnection = (HttpURLConnection) connection;
-            if (entry != null) {
-                if (entry.getTime() != -1) {
-                    httpConnection.setRequestProperty("If-Modified-Since", FORMAT.format(new Date(entry.getTime())));
-                }
-                if (entry.getEtag() != null) {
-                    httpConnection.setRequestProperty("If-None-Match", entry.getEtag());
-                }
-            }
-            responseCode = httpConnection.getResponseCode();
-        }
-        InputStream in = null;
-        try {
-            in = connection.getInputStream();
-            String etag = connection.getHeaderField("ETag");
-            long lastModifiedTimestamp;
-            long expireTimestamp = -1;
-            String maxAge = connection.getHeaderField("max-age");
-            if (maxAge != null && !maxAge.isEmpty()) {
-                try {
-                    expireTimestamp = requestTime + Long.parseLong(maxAge) * 1000;
-                } catch (NumberFormatException e) {
-                }
-            }
-            String expires = connection.getHeaderField("Expires");
-            if (expires != null && !expires.isEmpty()) {
-                try {
-                    expireTimestamp = FORMAT.parse(expires).getTime();
-                } catch (ParseException e) {
-                }
-            }
-            String lastModified = connection.getHeaderField("Last-Modified");
-            if (lastModified != null && !lastModified.isEmpty()) {
-                try {
-                    lastModifiedTimestamp = FORMAT.parse(lastModified).getTime();
-                } catch (ParseException e) {
-                    lastModifiedTimestamp = requestTime;
-                }
-            } else {
-                lastModifiedTimestamp = requestTime;
-            }
-            if (entry != null) {
-                if (etag != null && !etag.isEmpty()) {
-                    entry.setEtag(etag);
-                }
-                entry.setTime(lastModifiedTimestamp);
-                if (responseCode == HttpURLConnection.HTTP_NOT_MODIFIED) {
-                    File file = entry.getFile();
-                    if (file.exists()) {
-                        return IOUtils.toByteArray(new FileInputStream(file));
-                    }
-                }
-            }
-            byte[] data = IOUtils.toByteArray(in);
-            TEXTURE_CACHE.save(url, etag, lastModifiedTimestamp, expireTimestamp, data);
-            return data;
-        } finally {
-            IOUtils.closeQuietly(in);
-        }
-    }
+	public static byte[] load(String url) throws IOException {
+		TextureCache.CacheEntry entry = TEXTURE_CACHE.getEntry(url);
+		long requestTime = System.currentTimeMillis();
+		URLConnection connection = new URL(url).openConnection();
+		connection.addRequestProperty("User-Agent", "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)");
+		int responseCode = -1;
+		if (connection instanceof HttpURLConnection) {
+			HttpURLConnection httpConnection = (HttpURLConnection) connection;
+			if (entry != null) {
+				if (entry.getTime() != -1) {
+					httpConnection.setRequestProperty("If-Modified-Since", FORMAT.format(new Date(entry.getTime())));
+				}
+				if (entry.getEtag() != null) {
+					httpConnection.setRequestProperty("If-None-Match", entry.getEtag());
+				}
+			}
+			responseCode = httpConnection.getResponseCode();
+		}
+		InputStream in = null;
+		try {
+			in = connection.getInputStream();
+			String etag = connection.getHeaderField("ETag");
+			long lastModifiedTimestamp;
+			long expireTimestamp = -1;
+			String maxAge = connection.getHeaderField("max-age");
+			if (maxAge != null && !maxAge.isEmpty()) {
+				try {
+					expireTimestamp = requestTime + Long.parseLong(maxAge) * 1000;
+				}
+				catch (NumberFormatException e) {
+				}
+			}
+			String expires = connection.getHeaderField("Expires");
+			if (expires != null && !expires.isEmpty()) {
+				try {
+					expireTimestamp = FORMAT.parse(expires).getTime();
+				}
+				catch (ParseException e) {
+				}
+			}
+			String lastModified = connection.getHeaderField("Last-Modified");
+			if (lastModified != null && !lastModified.isEmpty()) {
+				try {
+					lastModifiedTimestamp = FORMAT.parse(lastModified).getTime();
+				}
+				catch (ParseException e) {
+					lastModifiedTimestamp = requestTime;
+				}
+			}
+			else {
+				lastModifiedTimestamp = requestTime;
+			}
+			if (entry != null) {
+				if (etag != null && !etag.isEmpty()) {
+					entry.setEtag(etag);
+				}
+				entry.setTime(lastModifiedTimestamp);
+				if (responseCode == HttpURLConnection.HTTP_NOT_MODIFIED) {
+					File file = entry.getFile();
+					if (file.exists()) {
+						return IOUtils.toByteArray(new FileInputStream(file));
+					}
+				}
+			}
+			byte[] data = IOUtils.toByteArray(in);
+			TEXTURE_CACHE.save(url, etag, lastModifiedTimestamp, expireTimestamp, data);
+			return data;
+		}
+		finally {
+			IOUtils.closeQuietly(in);
+		}
+	}
 
-    private static String readType(byte[] input) throws IOException {
-        InputStream in = null;
-        try {
-            in = new ByteArrayInputStream(input);
-            return readType(in);
-        } finally {
-            IOUtils.closeQuietly(in);
-        }
-    }
+	private static String readType(byte[] input) throws IOException {
+		InputStream in = null;
+		try {
+			in = new ByteArrayInputStream(input);
+			return readType(in);
+		}
+		finally {
+			IOUtils.closeQuietly(in);
+		}
+	}
 
-    private static String readType(InputStream input) throws IOException {
-        ImageInputStream stream = ImageIO.createImageInputStream(input);
-        Iterator iter = ImageIO.getImageReaders(stream);
-        if (!iter.hasNext()) {
-            return "";
-        }
-        ImageReader reader = (ImageReader) iter.next();
-        ImageReadParam param = reader.getDefaultReadParam();
-        reader.setInput(stream, true, true);
-        try {
-            reader.read(0, param);
-        } catch (IOException e) {
-            LOGGER.error("Failed to parse input format", e);
-        } finally {
-            reader.dispose();
-            IOUtils.closeQuietly(stream);
-        }
-        input.reset();
-        return reader.getFormatName();
-    }
+	private static String readType(InputStream input) throws IOException {
+		ImageInputStream stream = ImageIO.createImageInputStream(input);
+		Iterator iter = ImageIO.getImageReaders(stream);
+		if (!iter.hasNext()) {
+			return "";
+		}
+		ImageReader reader = (ImageReader) iter.next();
+		ImageReadParam param = reader.getDefaultReadParam();
+		reader.setInput(stream, true, true);
+		try {
+			reader.read(0, param);
+		}
+		catch (IOException e) {
+			LOGGER.error("Failed to parse input format", e);
+		}
+		finally {
+			reader.dispose();
+			IOUtils.closeQuietly(stream);
+		}
+		input.reset();
+		return reader.getFormatName();
+	}
 
-    public static PictureTexture loadImage(DownloadThread thread) {
-        PictureTexture texture = null;
-        if (!thread.hasFailed()) {
-            if (thread.processedImage.isAnimated()) {
-                texture = new AnimatedPictureTexture(thread.processedImage);
-            } else {
-                texture = new OrdinaryTexture(thread.processedImage);
-            }
-        }
-        if (texture != null) {
-            synchronized (LOCK) {
-                loadedImages.put(thread.url, texture);
-            }
-        }
-        return texture;
-    }
+	public static PictureTexture loadImage(DownloadThread thread) {
+		PictureTexture texture = null;
+		if (!thread.hasFailed()) {
+			if (thread.processedImage.isAnimated()) {
+				texture = new AnimatedPictureTexture(thread.processedImage);
+			}
+			else {
+				texture = new OrdinaryTexture(thread.processedImage);
+			}
+		}
+		if (texture != null) {
+			synchronized (LOCK) {
+				loadedImages.put(thread.url, texture);
+			}
+		}
+		return texture;
+	}
 }

--- a/src/main/java/com/creativemd/opf/client/DownloadThread.java
+++ b/src/main/java/com/creativemd/opf/client/DownloadThread.java
@@ -25,10 +25,11 @@ import java.net.URLConnection;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Set;
 
 @SideOnly(Side.CLIENT)
 public class DownloadThread extends Thread {
@@ -42,7 +43,7 @@ public class DownloadThread extends Thread {
 	public static int activeDownloads = 0;
 
 	public static HashMap<String, PictureTexture> loadedImages = new HashMap<String, PictureTexture>();
-	public static ArrayList<String> loadingImages = new ArrayList<String>();
+	public static Set<String> loadingImages = new HashSet<String>();
 
 	private String url;
 
@@ -83,7 +84,7 @@ public class DownloadThread extends Thread {
 						processedImage = new ProcessedImageData(gif);
 					}
 					else {
-						LOGGER.error("Failed to read gif: " + status);
+						LOGGER.error("Failed to read gif: {}", status);
 					}
 				}
 				else {

--- a/src/main/java/com/creativemd/opf/client/OrdinaryTexture.java
+++ b/src/main/java/com/creativemd/opf/client/OrdinaryTexture.java
@@ -3,7 +3,7 @@ package com.creativemd.opf.client;
 public class OrdinaryTexture extends PictureTexture {
 
 	private final int textureID;
-	
+
 	public OrdinaryTexture(ProcessedImageData image) {
 		super(image.getWidth(), image.getHeight());
 		textureID = image.uploadFrame(0);

--- a/src/main/java/com/creativemd/opf/client/OrdinaryTexture.java
+++ b/src/main/java/com/creativemd/opf/client/OrdinaryTexture.java
@@ -10,6 +10,10 @@ public class OrdinaryTexture extends PictureTexture {
 	}
 
 	@Override
+	public void tick() {
+	}
+
+	@Override
 	public int getTextureID() {
 		return textureID;
 	}

--- a/src/main/java/com/creativemd/opf/client/OrdinaryTexture.java
+++ b/src/main/java/com/creativemd/opf/client/OrdinaryTexture.java
@@ -1,14 +1,12 @@
 package com.creativemd.opf.client;
 
-import java.awt.image.BufferedImage;
-
 public class OrdinaryTexture extends PictureTexture {
 
 	private final int textureID;
 	
-	public OrdinaryTexture(BufferedImage image) {
+	public OrdinaryTexture(ProcessedImageData image) {
 		super(image.getWidth(), image.getHeight());
-		this.textureID = DownloadThread.loadTexture(image);
+		textureID = image.uploadFrame(0);
 	}
 
 	@Override

--- a/src/main/java/com/creativemd/opf/client/PicTileRenderer.java
+++ b/src/main/java/com/creativemd/opf/client/PicTileRenderer.java
@@ -20,70 +20,74 @@ public class PicTileRenderer extends TileEntitySpecialRenderer<TileEntityPicFram
 		{
 			if(frame.isTextureLoaded())
 			{
-				float sizeX = frame.sizeX;
-				float sizeY = frame.sizeY;
-				
-				GlStateManager.enableBlend();
-	            OpenGlHelper.glBlendFunc(770, 771, 1, 0);
-	            GlStateManager.disableLighting();
-	            GlStateManager.color(1, 1, 1, 1);
-	            GlStateManager.bindTexture(frame.texture.getTextureID());
-	            
-	            GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_NEAREST);
-	            GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_NEAREST);
-	            
-	            GlStateManager.pushMatrix();
-	            
-	    		GL11.glTranslated(x+0.5, y+0.5, z+0.5);
-	    		
-	    		EnumFacing direction = EnumFacing.getFront(meta);
-	    		RenderHelper3D.applyDirection(direction);
-	    		if(direction == EnumFacing.UP || direction == EnumFacing.DOWN)
-	    			GL11.glRotatef(90, 0, 1, 0);
-	    		
-	    		double posX = -0.5+sizeX/2D;
-	    		if(frame.posX == 1)
-	    			posX = 0;
-	    		else if(frame.posX == 2)
-	    			posX = -posX;
-	    		double posY = -0.5+sizeY/2D;
-	    		if(frame.posY == 1)
-	    			posY = 0;
-	    		else if(frame.posY == 2)
-	    			posY = -posY;
-	    		
-	    		if((frame.rotation == 1 || frame.rotation == 3) && (frame.posX == 2 ^ frame.posY == 2))
-	    			GL11.glRotated(180, 1, 0, 0);
-	    		
-	    		GL11.glRotated(frame.rotation * 90, 1, 0, 0);
-	    		
-	    		GL11.glRotated(frame.rotationX, 0, 1, 0);
-	    		GL11.glRotated(frame.rotationY, 0, 0, 1);
-	    		
-	    		GL11.glTranslated(-0.945, posY, posX);
-	    		
-	    		
-	    		GlStateManager.enableRescaleNormal();
-	    		GL11.glScaled(1, frame.sizeY, frame.sizeX);
-	    		
-	    		GL11.glBegin(GL11.GL_POLYGON);
-	    		GL11.glNormal3f(1.0f, 0.0F, 0.0f);
-	    		
-	    		GL11.glTexCoord3f(frame.flippedY ? 0 : 1, frame.flippedX ? 0 : 1, 0);
-	    		GL11.glVertex3f(0.5F, -0.5f, -0.5f);
-	    		GL11.glTexCoord3f(frame.flippedY ? 0 : 1, frame.flippedX ? 1 : 0, 0);
-	    		GL11.glVertex3f(0.5f, 0.5f, -0.5f);
-	    		GL11.glTexCoord3f(frame.flippedY ? 1 : 0, frame.flippedX ? 1 : 0, 0);
-	    		GL11.glVertex3f(0.5f, 0.5f, 0.5f);
-	    		GL11.glTexCoord3f(frame.flippedY ? 1 : 0, frame.flippedX ? 0 : 1, 0);
-	    		GL11.glVertex3f(0.5f, -0.5f, 0.5f);
-	    		GL11.glEnd();
-	    		
-	    		GlStateManager.popMatrix();
-	    		
-	    		GlStateManager.disableRescaleNormal();
-	            GlStateManager.disableBlend();
-	            GlStateManager.enableLighting();
+				int textureID = frame.texture.getTextureID();
+
+				if (textureID != -1) {
+					float sizeX = frame.sizeX;
+					float sizeY = frame.sizeY;
+
+					GlStateManager.enableBlend();
+					OpenGlHelper.glBlendFunc(770, 771, 1, 0);
+					GlStateManager.disableLighting();
+					GlStateManager.color(1, 1, 1, 1);
+					GlStateManager.bindTexture(textureID);
+
+					GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_NEAREST);
+					GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_NEAREST);
+
+					GlStateManager.pushMatrix();
+
+					GL11.glTranslated(x + 0.5, y + 0.5, z + 0.5);
+
+					EnumFacing direction = EnumFacing.getFront(meta);
+					RenderHelper3D.applyDirection(direction);
+					if (direction == EnumFacing.UP || direction == EnumFacing.DOWN)
+						GL11.glRotatef(90, 0, 1, 0);
+
+					double posX = -0.5 + sizeX / 2D;
+					if (frame.posX == 1)
+						posX = 0;
+					else if (frame.posX == 2)
+						posX = -posX;
+					double posY = -0.5 + sizeY / 2D;
+					if (frame.posY == 1)
+						posY = 0;
+					else if (frame.posY == 2)
+						posY = -posY;
+
+					if ((frame.rotation == 1 || frame.rotation == 3) && (frame.posX == 2 ^ frame.posY == 2))
+						GL11.glRotated(180, 1, 0, 0);
+
+					GL11.glRotated(frame.rotation * 90, 1, 0, 0);
+
+					GL11.glRotated(frame.rotationX, 0, 1, 0);
+					GL11.glRotated(frame.rotationY, 0, 0, 1);
+
+					GL11.glTranslated(-0.945, posY, posX);
+
+
+					GlStateManager.enableRescaleNormal();
+					GL11.glScaled(1, frame.sizeY, frame.sizeX);
+
+					GL11.glBegin(GL11.GL_POLYGON);
+					GL11.glNormal3f(1.0f, 0.0F, 0.0f);
+
+					GL11.glTexCoord3f(frame.flippedY ? 0 : 1, frame.flippedX ? 0 : 1, 0);
+					GL11.glVertex3f(0.5F, -0.5f, -0.5f);
+					GL11.glTexCoord3f(frame.flippedY ? 0 : 1, frame.flippedX ? 1 : 0, 0);
+					GL11.glVertex3f(0.5f, 0.5f, -0.5f);
+					GL11.glTexCoord3f(frame.flippedY ? 1 : 0, frame.flippedX ? 1 : 0, 0);
+					GL11.glVertex3f(0.5f, 0.5f, 0.5f);
+					GL11.glTexCoord3f(frame.flippedY ? 1 : 0, frame.flippedX ? 0 : 1, 0);
+					GL11.glVertex3f(0.5f, -0.5f, 0.5f);
+					GL11.glEnd();
+
+					GlStateManager.popMatrix();
+
+					GlStateManager.disableRescaleNormal();
+					GlStateManager.disableBlend();
+					GlStateManager.enableLighting();
+				}
 			}else{
 				frame.loadTexture();
 			}

--- a/src/main/java/com/creativemd/opf/client/PicTileRenderer.java
+++ b/src/main/java/com/creativemd/opf/client/PicTileRenderer.java
@@ -1,7 +1,6 @@
 package com.creativemd.opf.client;
 
 import org.lwjgl.opengl.GL11;
-import org.lwjgl.opengl.GL12;
 
 import com.creativemd.creativecore.client.rendering.RenderHelper3D;
 import com.creativemd.opf.block.TileEntityPicFrame;
@@ -9,7 +8,6 @@ import com.creativemd.opf.block.TileEntityPicFrame;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -87,7 +85,7 @@ public class PicTileRenderer extends TileEntitySpecialRenderer<TileEntityPicFram
 	            GlStateManager.disableBlend();
 	            GlStateManager.enableLighting();
 			}else{
-				frame.loadTexutre();
+				frame.loadTexture();
 			}
 		}
 	}

--- a/src/main/java/com/creativemd/opf/client/PictureTexture.java
+++ b/src/main/java/com/creativemd/opf/client/PictureTexture.java
@@ -1,7 +1,5 @@
 package com.creativemd.opf.client;
 
-import java.awt.image.BufferedImage;
-
 public abstract class PictureTexture {
 	
 	
@@ -14,7 +12,9 @@ public abstract class PictureTexture {
 		this.height = height;
 		
 	}
-	
+
+	public abstract void tick();
+
 	public abstract int getTextureID();
 	
 }

--- a/src/main/java/com/creativemd/opf/client/ProcessedImageData.java
+++ b/src/main/java/com/creativemd/opf/client/ProcessedImageData.java
@@ -10,128 +10,128 @@ import java.awt.image.BufferedImage;
 import java.nio.ByteBuffer;
 
 public class ProcessedImageData {
-    private final int width;
-    private final int height;
-    private final Frame[] frames;
-    private final long[] delay;
-    private final long duration;
+	private final int width;
+	private final int height;
+	private final Frame[] frames;
+	private final long[] delay;
+	private final long duration;
 
-    public ProcessedImageData(BufferedImage image) {
-        width = image.getWidth();
-        height = image.getHeight();
-        frames = new Frame[] { loadFrom(image) };
-        delay = new long[] { 0 };
-        duration = 0;
-    }
+	public ProcessedImageData(BufferedImage image) {
+		width = image.getWidth();
+		height = image.getHeight();
+		frames = new Frame[] { loadFrom(image) };
+		delay = new long[] { 0 };
+		duration = 0;
+	}
 
-    public ProcessedImageData(GifDecoder decoder) {
-        Dimension frameSize = decoder.getFrameSize();
-        width = (int) frameSize.getWidth();
-        height = (int) frameSize.getHeight();
-        frames = new Frame[decoder.getFrameCount()];
-        delay = new long[decoder.getFrameCount()];
-        long time = 0;
-        for (int i = 0; i < decoder.getFrameCount(); i++) {
-            frames[i] = loadFrom(decoder.getFrame(i));
-            delay[i] = time;
-            time += decoder.getDelay(i);
-        }
-        duration = time;
-    }
+	public ProcessedImageData(GifDecoder decoder) {
+		Dimension frameSize = decoder.getFrameSize();
+		width = (int) frameSize.getWidth();
+		height = (int) frameSize.getHeight();
+		frames = new Frame[decoder.getFrameCount()];
+		delay = new long[decoder.getFrameCount()];
+		long time = 0;
+		for (int i = 0; i < decoder.getFrameCount(); i++) {
+			frames[i] = loadFrom(decoder.getFrame(i));
+			delay[i] = time;
+			time += decoder.getDelay(i);
+		}
+		duration = time;
+	}
 
-    public int getWidth() {
-        return width;
-    }
+	public int getWidth() {
+		return width;
+	}
 
-    public int getHeight() {
-        return height;
-    }
+	public int getHeight() {
+		return height;
+	}
 
-    public long[] getDelay() {
-        return delay;
-    }
+	public long[] getDelay() {
+		return delay;
+	}
 
-    public long getDuration() {
-        return duration;
-    }
+	public long getDuration() {
+		return duration;
+	}
 
-    public boolean isAnimated() {
-        return frames.length > 1;
-    }
+	public boolean isAnimated() {
+		return frames.length > 1;
+	}
 
-    public int getFrameCount() {
-        return frames.length;
-    }
+	public int getFrameCount() {
+		return frames.length;
+	}
 
-    public int uploadFrame(int index) {
-        if (index >= 0 && index < frames.length) {
-            Frame frame = frames[index];
-            if (frame != null) {
-                frames[index] = null;
-                return uploadFrame(frame.buffer, frame.hasAlpha, width, height);
-            }
-        }
-        return -1;
-    }
+	public int uploadFrame(int index) {
+		if (index >= 0 && index < frames.length) {
+			Frame frame = frames[index];
+			if (frame != null) {
+				frames[index] = null;
+				return uploadFrame(frame.buffer, frame.hasAlpha, width, height);
+			}
+		}
+		return -1;
+	}
 
-    private static int uploadFrame(ByteBuffer buffer, boolean hasAlpha, int width, int height) {
-        int textureID = GL11.glGenTextures(); //Generate texture ID
-        GL11.glBindTexture(GL11.GL_TEXTURE_2D, textureID); //Bind texture ID
+	private static int uploadFrame(ByteBuffer buffer, boolean hasAlpha, int width, int height) {
+		int textureID = GL11.glGenTextures(); //Generate texture ID
+		GL11.glBindTexture(GL11.GL_TEXTURE_2D, textureID); //Bind texture ID
 
-        //Setup wrap mode
-        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, GL12.GL_CLAMP_TO_EDGE);
-        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, GL12.GL_CLAMP_TO_EDGE);
+		//Setup wrap mode
+		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, GL12.GL_CLAMP_TO_EDGE);
+		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, GL12.GL_CLAMP_TO_EDGE);
 
-        //Setup texture scaling filtering
-        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR);
-        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_LINEAR);
+		//Setup texture scaling filtering
+		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR);
+		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_LINEAR);
 
-        if (!hasAlpha) {
-            GL11.glPixelStorei(GL11.GL_UNPACK_ALIGNMENT, 1);
-        }
+		if (!hasAlpha) {
+			GL11.glPixelStorei(GL11.GL_UNPACK_ALIGNMENT, 1);
+		}
 
-        //Send texel data to OpenGL
-        GL11.glTexImage2D(GL11.GL_TEXTURE_2D, 0, hasAlpha ? GL11.GL_RGBA8 : GL11.GL_RGB8, width, height, 0, hasAlpha ? GL11.GL_RGBA : GL11.GL_RGB, GL11.GL_UNSIGNED_BYTE, buffer);
+		//Send texel data to OpenGL
+		GL11.glTexImage2D(GL11.GL_TEXTURE_2D, 0, hasAlpha ? GL11.GL_RGBA8 : GL11.GL_RGB8, width, height, 0, hasAlpha ? GL11.GL_RGBA : GL11.GL_RGB, GL11.GL_UNSIGNED_BYTE, buffer);
 
-        //Return the texture ID so we can bind it later again
-        return textureID;
-    }
+		//Return the texture ID so we can bind it later again
+		return textureID;
+	}
 
-    private static Frame loadFrom(BufferedImage image) {
-        int width = image.getWidth();
-        int height = image.getHeight();
-        int[] pixels = new int[width * height];
-        image.getRGB(0, 0, width, height, pixels, 0, width);
-        boolean hasAlpha = false;
-        if (image.getColorModel().hasAlpha()) {
-            for (int pixel : pixels) {
-                if ((pixel >> 24 & 0xFF) < 0xFF) {
-                    hasAlpha = true;
-                    break;
-                }
-            }
-        }
-        int bytesPerPixel = hasAlpha ? 4 : 3;
-        ByteBuffer buffer = BufferUtils.createByteBuffer(width * height * bytesPerPixel);
-        for (int pixel : pixels) {
-            buffer.put((byte) ((pixel >> 16) & 0xFF));     // Red component
-            buffer.put((byte) ((pixel >> 8) & 0xFF));      // Green component
-            buffer.put((byte) (pixel & 0xFF));             // Blue component
-            if (hasAlpha) {
-                buffer.put((byte) ((pixel >> 24) & 0xFF)); // Alpha component. Only for RGBA
-            }
-        }
-        buffer.flip();
-        return new Frame(buffer, hasAlpha);
-    }
+	private static Frame loadFrom(BufferedImage image) {
+		int width = image.getWidth();
+		int height = image.getHeight();
+		int[] pixels = new int[width * height];
+		image.getRGB(0, 0, width, height, pixels, 0, width);
+		boolean hasAlpha = false;
+		if (image.getColorModel().hasAlpha()) {
+			for (int pixel : pixels) {
+				if ((pixel >> 24 & 0xFF) < 0xFF) {
+					hasAlpha = true;
+					break;
+				}
+			}
+		}
+		int bytesPerPixel = hasAlpha ? 4 : 3;
+		ByteBuffer buffer = BufferUtils.createByteBuffer(width * height * bytesPerPixel);
+		for (int pixel : pixels) {
+			buffer.put((byte) ((pixel >> 16) & 0xFF));     // Red component
+			buffer.put((byte) ((pixel >> 8) & 0xFF));      // Green component
+			buffer.put((byte) (pixel & 0xFF));             // Blue component
+			if (hasAlpha) {
+				buffer.put((byte) ((pixel >> 24) & 0xFF)); // Alpha component. Only for RGBA
+			}
+		}
+		buffer.flip();
+		return new Frame(buffer, hasAlpha);
+	}
 
-    private static class Frame {
-        private final ByteBuffer buffer;
-        private final boolean hasAlpha;
+	private static class Frame {
+		private final ByteBuffer buffer;
+		private final boolean hasAlpha;
 
-        public Frame(ByteBuffer buffer, boolean alpha) {
-            this.buffer = buffer;
-            this.hasAlpha = alpha;
-        }
-    }
+		public Frame(ByteBuffer buffer, boolean alpha) {
+			this.buffer = buffer;
+			this.hasAlpha = alpha;
+		}
+	}
 }

--- a/src/main/java/com/creativemd/opf/client/ProcessedImageData.java
+++ b/src/main/java/com/creativemd/opf/client/ProcessedImageData.java
@@ -1,0 +1,137 @@
+package com.creativemd.opf.client;
+
+import com.porpit.lib.GifDecoder;
+import org.lwjgl.BufferUtils;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
+
+import java.awt.Dimension;
+import java.awt.image.BufferedImage;
+import java.nio.ByteBuffer;
+
+public class ProcessedImageData {
+    private final int width;
+    private final int height;
+    private final Frame[] frames;
+    private final long[] delay;
+    private final long duration;
+
+    public ProcessedImageData(BufferedImage image) {
+        width = image.getWidth();
+        height = image.getHeight();
+        frames = new Frame[] { loadFrom(image) };
+        delay = new long[] { 0 };
+        duration = 0;
+    }
+
+    public ProcessedImageData(GifDecoder decoder) {
+        Dimension frameSize = decoder.getFrameSize();
+        width = (int) frameSize.getWidth();
+        height = (int) frameSize.getHeight();
+        frames = new Frame[decoder.getFrameCount()];
+        delay = new long[decoder.getFrameCount()];
+        long time = 0;
+        for (int i = 0; i < decoder.getFrameCount(); i++) {
+            frames[i] = loadFrom(decoder.getFrame(i));
+            delay[i] = time;
+            time += decoder.getDelay(i);
+        }
+        duration = time;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public long[] getDelay() {
+        return delay;
+    }
+
+    public long getDuration() {
+        return duration;
+    }
+
+    public boolean isAnimated() {
+        return frames.length > 1;
+    }
+
+    public int getFrameCount() {
+        return frames.length;
+    }
+
+    public int uploadFrame(int index) {
+        if (index >= 0 && index < frames.length) {
+            Frame frame = frames[index];
+            if (frame != null) {
+                frames[index] = null;
+                return uploadFrame(frame.buffer, frame.hasAlpha, width, height);
+            }
+        }
+        return -1;
+    }
+
+    private static int uploadFrame(ByteBuffer buffer, boolean hasAlpha, int width, int height) {
+        int textureID = GL11.glGenTextures(); //Generate texture ID
+        GL11.glBindTexture(GL11.GL_TEXTURE_2D, textureID); //Bind texture ID
+
+        //Setup wrap mode
+        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, GL12.GL_CLAMP_TO_EDGE);
+        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, GL12.GL_CLAMP_TO_EDGE);
+
+        //Setup texture scaling filtering
+        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR);
+        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_LINEAR);
+
+        if (!hasAlpha) {
+            GL11.glPixelStorei(GL11.GL_UNPACK_ALIGNMENT, 1);
+        }
+
+        //Send texel data to OpenGL
+        GL11.glTexImage2D(GL11.GL_TEXTURE_2D, 0, hasAlpha ? GL11.GL_RGBA8 : GL11.GL_RGB8, width, height, 0, hasAlpha ? GL11.GL_RGBA : GL11.GL_RGB, GL11.GL_UNSIGNED_BYTE, buffer);
+
+        //Return the texture ID so we can bind it later again
+        return textureID;
+    }
+
+    private static Frame loadFrom(BufferedImage image) {
+        int width = image.getWidth();
+        int height = image.getHeight();
+        int[] pixels = new int[width * height];
+        image.getRGB(0, 0, width, height, pixels, 0, width);
+        boolean hasAlpha = false;
+        if (image.getColorModel().hasAlpha()) {
+            for (int pixel : pixels) {
+                if ((pixel >> 24 & 0xFF) < 0xFF) {
+                    hasAlpha = true;
+                    break;
+                }
+            }
+        }
+        int bytesPerPixel = hasAlpha ? 4 : 3;
+        ByteBuffer buffer = BufferUtils.createByteBuffer(width * height * bytesPerPixel);
+        for (int pixel : pixels) {
+            buffer.put((byte) ((pixel >> 16) & 0xFF));     // Red component
+            buffer.put((byte) ((pixel >> 8) & 0xFF));      // Green component
+            buffer.put((byte) (pixel & 0xFF));             // Blue component
+            if (hasAlpha) {
+                buffer.put((byte) ((pixel >> 24) & 0xFF)); // Alpha component. Only for RGBA
+            }
+        }
+        buffer.flip();
+        return new Frame(buffer, hasAlpha);
+    }
+
+    private static class Frame {
+        private final ByteBuffer buffer;
+        private final boolean hasAlpha;
+
+        public Frame(ByteBuffer buffer, boolean alpha) {
+            this.buffer = buffer;
+            this.hasAlpha = alpha;
+        }
+    }
+}

--- a/src/main/java/com/creativemd/opf/client/cache/TextureCache.java
+++ b/src/main/java/com/creativemd/opf/client/cache/TextureCache.java
@@ -40,7 +40,7 @@ public class TextureCache {
 			saved = true;
 		}
 		catch (IOException e) {
-			DownloadThread.LOGGER.error("Failed to save cache entry " + url, e);
+			DownloadThread.LOGGER.error("Failed to save cache entry {}", e, url);
 		}
 		finally {
 			IOUtils.closeQuietly(out);

--- a/src/main/java/com/creativemd/opf/client/cache/TextureCache.java
+++ b/src/main/java/com/creativemd/opf/client/cache/TextureCache.java
@@ -18,128 +18,134 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 public class TextureCache {
-    private File cacheDirectory = new File(Minecraft.getMinecraft().mcDataDir, "opframe_cache");
-    private File index = new File(cacheDirectory, "index");
+	private File cacheDirectory = new File(Minecraft.getMinecraft().mcDataDir, "opframe_cache");
+	private File index = new File(cacheDirectory, "index");
 
-    private Map<String, CacheEntry> entries = new HashMap<String, CacheEntry>();
+	private Map<String, CacheEntry> entries = new HashMap<String, CacheEntry>();
 
-    public TextureCache() {
-        if (!cacheDirectory.exists()) {
-            cacheDirectory.mkdirs();
-        }
-        loadIndex();
-    }
+	public TextureCache() {
+		if (!cacheDirectory.exists()) {
+			cacheDirectory.mkdirs();
+		}
+		loadIndex();
+	}
 
-    public void save(String url, String etag, long time, long expireTime, byte[] data) {
-        CacheEntry entry = new CacheEntry(url, etag, time, expireTime);
-        boolean saved = false;
-        OutputStream out = null;
-        try {
-            out = new FileOutputStream(entry.getFile());
-            out.write(data);
-            saved = true;
-        } catch (IOException e) {
-            DownloadThread.LOGGER.error("Failed to save cache entry " + url, e);
-        } finally {
-            IOUtils.closeQuietly(out);
-        }
-        if (saved) {
-            entries.put(url, entry);
-            saveIndex();
-        }
-    }
+	public void save(String url, String etag, long time, long expireTime, byte[] data) {
+		CacheEntry entry = new CacheEntry(url, etag, time, expireTime);
+		boolean saved = false;
+		OutputStream out = null;
+		try {
+			out = new FileOutputStream(entry.getFile());
+			out.write(data);
+			saved = true;
+		}
+		catch (IOException e) {
+			DownloadThread.LOGGER.error("Failed to save cache entry " + url, e);
+		}
+		finally {
+			IOUtils.closeQuietly(out);
+		}
+		if (saved) {
+			entries.put(url, entry);
+			saveIndex();
+		}
+	}
 
-    public CacheEntry getEntry(String url) {
-        return entries.get(url);
-    }
+	public CacheEntry getEntry(String url) {
+		return entries.get(url);
+	}
 
-    private void loadIndex() {
-        if (index.exists()) {
-            Map<String, CacheEntry> previousEntries = entries;
-            entries = new HashMap<String, CacheEntry>();
-            DataInputStream in = null;
-            try {
-                in = new DataInputStream(new GZIPInputStream(new FileInputStream(index)));
-                int length = in.readInt();
-                for (int i = 0; i < length; i++) {
-                    String url = in.readUTF();
-                    String etag = in.readUTF();
-                    long time = in.readLong();
-                    long expireTime = in.readLong();
-                    CacheEntry entry = new CacheEntry(url, etag.length() > 0 ? etag : null, time, expireTime);
-                    entries.put(entry.getUrl(), entry);
-                }
-            } catch (IOException e) {
-                DownloadThread.LOGGER.error("Failed to load cache index", e);
-                entries = previousEntries;
-            } finally {
-                IOUtils.closeQuietly(in);
-            }
-        }
-    }
+	private void loadIndex() {
+		if (index.exists()) {
+			Map<String, CacheEntry> previousEntries = entries;
+			entries = new HashMap<String, CacheEntry>();
+			DataInputStream in = null;
+			try {
+				in = new DataInputStream(new GZIPInputStream(new FileInputStream(index)));
+				int length = in.readInt();
+				for (int i = 0; i < length; i++) {
+					String url = in.readUTF();
+					String etag = in.readUTF();
+					long time = in.readLong();
+					long expireTime = in.readLong();
+					CacheEntry entry = new CacheEntry(url, etag.length() > 0 ? etag : null, time, expireTime);
+					entries.put(entry.getUrl(), entry);
+				}
+			}
+			catch (IOException e) {
+				DownloadThread.LOGGER.error("Failed to load cache index", e);
+				entries = previousEntries;
+			}
+			finally {
+				IOUtils.closeQuietly(in);
+			}
+		}
+	}
 
-    private void saveIndex() {
-        DataOutputStream out = null;
-        try {
-            out = new DataOutputStream(new GZIPOutputStream(new FileOutputStream(index)));
-            out.writeInt(entries.size());
-            for (Map.Entry<String, CacheEntry> mapEntry : entries.entrySet()) {
-                CacheEntry entry = mapEntry.getValue();
-                out.writeUTF(entry.getUrl());
-                out.writeUTF(entry.getEtag() == null ? "" : entry.getEtag());
-                out.writeLong(entry.getTime());
-                out.writeLong(entry.getExpireTime());
-            }
-        } catch (IOException e) {
-            DownloadThread.LOGGER.error("Failed to save cache index", e);
-        } finally {
-            IOUtils.closeQuietly(out);
-        }
-    }
+	private void saveIndex() {
+		DataOutputStream out = null;
+		try {
+			out = new DataOutputStream(new GZIPOutputStream(new FileOutputStream(index)));
+			out.writeInt(entries.size());
+			for (Map.Entry<String, CacheEntry> mapEntry : entries.entrySet()) {
+				CacheEntry entry = mapEntry.getValue();
+				out.writeUTF(entry.getUrl());
+				out.writeUTF(entry.getEtag() == null ? "" : entry.getEtag());
+				out.writeLong(entry.getTime());
+				out.writeLong(entry.getExpireTime());
+			}
+		}
+		catch (IOException e) {
+			DownloadThread.LOGGER.error("Failed to save cache index", e);
+		}
+		finally {
+			IOUtils.closeQuietly(out);
+		}
+	}
 
-    public static class CacheEntry {
-        private String url;
-        private String etag;
-        private long time;
-        private long expireTime;
+	public static class CacheEntry {
+		private String url;
+		private String etag;
+		private long time;
+		private long expireTime;
 
-        public CacheEntry(String url, String etag, long time, long expireTime) {
-            this.url = url;
-            this.etag = etag;
-            this.time = time;
-            this.expireTime = expireTime;
-        }
+		public CacheEntry(String url, String etag, long time, long expireTime) {
+			this.url = url;
+			this.etag = etag;
+			this.time = time;
+			this.expireTime = expireTime;
+		}
 
-        public void setEtag(String etag) {
-            this.etag = etag;
-        }
+		public void setEtag(String etag) {
+			this.etag = etag;
+		}
 
-        public void setTime(long time) {
-            this.time = time;
-        }
+		public void setTime(long time) {
+			this.time = time;
+		}
 
-        public void setExpireTime(long expireTime) {
-            this.expireTime = expireTime;
-        }
+		public void setExpireTime(long expireTime) {
+			this.expireTime = expireTime;
+		}
 
-        public String getUrl() {
-            return url;
-        }
+		public String getUrl() {
+			return url;
+		}
 
-        public String getEtag() {
-            return etag;
-        }
+		public String getEtag() {
+			return etag;
+		}
 
-        public long getTime() {
-            return time;
-        }
+		public long getTime() {
+			return time;
+		}
 
-        public long getExpireTime() {
-            return expireTime;
-        }
+		public long getExpireTime() {
+			return expireTime;
+		}
 
-        public File getFile() {
-            return new File(DownloadThread.TEXTURE_CACHE.cacheDirectory, Base64.encodeBase64String(url.getBytes()));
-        }
-    }
+		public File getFile() {
+			return new File(DownloadThread.TEXTURE_CACHE.cacheDirectory, Base64.encodeBase64String(url.getBytes()));
+		}
+	}
 }

--- a/src/main/java/com/creativemd/opf/client/cache/TextureCache.java
+++ b/src/main/java/com/creativemd/opf/client/cache/TextureCache.java
@@ -1,0 +1,172 @@
+package com.creativemd.opf.client.cache;
+
+import com.creativemd.opf.client.DownloadThread;
+import net.minecraft.client.Minecraft;
+import org.apache.commons.io.IOUtils;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TextureCache {
+    private File cacheDirectory = new File(Minecraft.getMinecraft().mcDataDir, "opframe_cache");
+    private File index = new File(cacheDirectory, "index");
+
+    private Map<String, CacheEntry> entries = new HashMap<>();
+
+    public TextureCache() {
+        if (!cacheDirectory.exists()) {
+            cacheDirectory.mkdirs();
+        }
+        loadIndex();
+    }
+
+    public void save(String url, String etag, long time, long expireTime, byte[] data) {
+        CacheEntry entry = new CacheEntry(url, etag, time, expireTime);
+        boolean saved = false;
+        try (OutputStream out = new FileOutputStream(entry.getFile())) {
+            out.write(data);
+            saved = true;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        if (saved) {
+            entries.put(url, entry);
+            saveIndex();
+        }
+    }
+
+    public byte[] load(String url) {
+        CacheEntry entry = entries.get(url);
+        if (entry != null) {
+            try (InputStream in = new FileInputStream(entry.getFile())) {
+                return IOUtils.toByteArray(in);
+            } catch (IOException e) {
+                e.printStackTrace();
+                return null;
+            }
+        }
+        return null;
+    }
+
+    public CacheEntry getEntry(String url) {
+        return entries.get(url);
+    }
+
+    private void loadIndex() {
+        if (index.exists()) {
+            Map<String, CacheEntry> previousEntries = entries;
+            entries = new HashMap<>();
+            try (DataInputStream in = new DataInputStream(new FileInputStream(index))) {
+                int length = in.readUnsignedShort();
+                for (int i = 0; i < length; i++) {
+                    StringBuilder url = new StringBuilder();
+                    int urlLength = in.readUnsignedByte();
+                    for (int c = 0; c < urlLength; c++) {
+                        url.append(in.readChar());
+                    }
+                    StringBuilder etag = new StringBuilder();
+                    int etagLength = in.readUnsignedByte();
+                    for (int c = 0; c < etagLength; c++) {
+                        etag.append(in.readChar());
+                    }
+                    long time = in.readLong();
+                    long expireTime = in.readLong();
+                    CacheEntry entry = new CacheEntry(url.toString(), etag.length() > 0 ? etag.toString() : null, time, expireTime);
+                    entries.put(entry.getUrl(), entry);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+                entries = previousEntries;
+            }
+        }
+    }
+
+    private void saveIndex() {
+        if (!index.exists()) {
+            try {
+                index.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        try (DataOutputStream out = new DataOutputStream(new FileOutputStream(index))) {
+            out.writeShort(entries.size());
+            for (Map.Entry<String, CacheEntry> mapEntry : entries.entrySet()) {
+                CacheEntry entry = mapEntry.getValue();
+                String url = entry.getUrl();
+                out.writeByte(url.length());
+                for (char c : url.toCharArray()) {
+                    out.writeChar(c);
+                }
+                String etag = entry.getEtag();
+                if (etag == null) {
+                    out.writeByte(0);
+                } else {
+                    out.writeByte(etag.length());
+                    for (char c : etag.toCharArray()) {
+                        out.writeChar(c);
+                    }
+                }
+                out.writeLong(entry.getTime());
+                out.writeLong(entry.getExpireTime());
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static class CacheEntry {
+        private String url;
+        private String etag;
+        private long time;
+        private long expireTime;
+
+        public CacheEntry(String url, String etag, long time, long expireTime) {
+            this.url = url;
+            this.etag = etag;
+            this.time = time;
+            this.expireTime = expireTime;
+        }
+
+        public void setEtag(String etag) {
+            this.etag = etag;
+        }
+
+        public void setTime(long time) {
+            this.time = time;
+        }
+
+        public void setExpireTime(long expireTime) {
+            this.expireTime = expireTime;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public String getEtag() {
+            return etag;
+        }
+
+        public long getTime() {
+            return time;
+        }
+
+        public long getExpireTime() {
+            return expireTime;
+        }
+
+        public File getFile() {
+            return new File(DownloadThread.TEXTURE_CACHE.cacheDirectory, Base64.getUrlEncoder().encodeToString(url.getBytes()));
+        }
+    }
+}

--- a/src/main/java/com/creativemd/opf/little/LittleOpFrame.java
+++ b/src/main/java/com/creativemd/opf/little/LittleOpFrame.java
@@ -1,29 +1,15 @@
 package com.creativemd.opf.little;
 
-import java.util.ArrayList;
-
-import javax.annotation.Nullable;
-import javax.vecmath.Matrix3d;
-import javax.vecmath.Matrix3f;
-import javax.vecmath.Vector3d;
-import javax.vecmath.Vector3f;
-
-import org.lwjgl.opengl.GL11;
-
 import com.creativemd.creativecore.client.rendering.RenderCubeObject;
 import com.creativemd.creativecore.client.rendering.RenderHelper3D;
 import com.creativemd.creativecore.common.utils.CubeObject;
-import com.creativemd.creativecore.gui.opener.GuiHandler;
 import com.creativemd.littletiles.common.gui.handler.LittleGuiHandler;
 import com.creativemd.littletiles.common.utils.LittleTile;
-import com.creativemd.littletiles.common.utils.LittleTileBlock;
 import com.creativemd.littletiles.common.utils.LittleTilePreview;
 import com.creativemd.littletiles.common.utils.LittleTileTileEntity;
 import com.creativemd.littletiles.common.utils.small.LittleTileVec;
 import com.creativemd.opf.OPFrame;
 import com.creativemd.opf.block.TileEntityPicFrame;
-import com.creativemd.opf.client.PicTileRenderer;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.GlStateManager;
@@ -33,19 +19,22 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.util.EnumHand;
 import net.minecraft.util.EnumFacing.Axis;
 import net.minecraft.util.EnumFacing.AxisDirection;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
-import net.minecraftforge.fml.relauncher.ReflectionHelper;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import org.lwjgl.opengl.GL11;
+
+import javax.annotation.Nullable;
+import javax.vecmath.Matrix3f;
+import javax.vecmath.Vector3f;
+import java.util.ArrayList;
 
 public class LittleOpFrame extends LittleTileTileEntity {
 	
@@ -186,7 +175,7 @@ public class LittleOpFrame extends LittleTileTileEntity {
 		if(!frame.url.equals(""))
 		{
 			if(!frame.isTextureLoaded())
-				frame.loadTexutre();
+				frame.loadTexture();
 			if(frame.isTextureLoaded())
 			{
 				float sizeX = frame.sizeX;

--- a/src/main/java/com/creativemd/opf/little/LittlePlaceOpPreview.java
+++ b/src/main/java/com/creativemd/opf/little/LittlePlaceOpPreview.java
@@ -1,7 +1,5 @@
 package com.creativemd.opf.little;
 
-import java.util.ArrayList;
-
 import com.creativemd.creativecore.common.utils.ColoredCube;
 import com.creativemd.creativecore.common.utils.CubeObject;
 import com.creativemd.littletiles.common.structure.LittleStructure;
@@ -11,8 +9,6 @@ import com.creativemd.littletiles.common.utils.LittleTilePreview;
 import com.creativemd.littletiles.common.utils.small.LittleTileBox;
 import com.creativemd.littletiles.utils.PlacePreviewTile;
 import com.creativemd.opf.block.TileEntityPicFrame;
-
-import io.netty.util.concurrent.ProgressiveFuture;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -25,6 +21,8 @@ import net.minecraftforge.fml.relauncher.ReflectionHelper;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import java.util.ArrayList;
+
 public class LittlePlaceOpPreview extends PlacePreviewTile {
 
 	public LittlePlaceOpPreview(LittleTileBox box, LittleTilePreview preview) {
@@ -36,7 +34,7 @@ public class LittlePlaceOpPreview extends PlacePreviewTile {
 	public ArrayList<ColoredCube> getPreviews()
 	{
 		NBTTagCompound nbt = preview.getTileData();
-		ArrayList<ColoredCube> cubes = new ArrayList<>();
+		ArrayList<ColoredCube> cubes = new ArrayList<ColoredCube>();
 		cubes.add(new ColoredCube(box.getCube()));
 		if(preview.box != null && nbt.hasKey("tileEntity"))
 		{

--- a/src/main/java/com/porpit/lib/GifDecoder.java
+++ b/src/main/java/com/porpit/lib/GifDecoder.java
@@ -281,8 +281,7 @@ public class GifDecoder {
 		status = STATUS_OK;
 		try {
 			name = name.trim().toLowerCase();
-			if ((name.indexOf("file:") >= 0) ||
-					(name.indexOf(":/") > 0)) {
+			if ((name.startsWith("file:")) || (name.indexOf(":/") > 0)) {
 				URL url = new URL(name);
 				in = new BufferedInputStream(url.openStream());
 			} else {
@@ -555,11 +554,11 @@ public class GifDecoder {
 	 * Reads GIF file header information.
 	 */
 	protected void readHeader() {
-		String id = "";
+		StringBuilder id = new StringBuilder();
 		for (int i = 0; i < 6; i++) {
-			id += (char) read();
+			id.append(read());
 		}
-		if (!id.startsWith("GIF")) {
+		if (!id.toString().startsWith("GIF")) {
 			status = STATUS_FORMAT_ERROR;
 			return;
 		}

--- a/src/main/java/com/porpit/lib/GifDecoder.java
+++ b/src/main/java/com/porpit/lib/GifDecoder.java
@@ -556,7 +556,7 @@ public class GifDecoder {
 	protected void readHeader() {
 		StringBuilder id = new StringBuilder();
 		for (int i = 0; i < 6; i++) {
-			id.append(read());
+			id.append((char) read());
 		}
 		if (!id.toString().startsWith("GIF")) {
 			status = STATUS_FORMAT_ERROR;


### PR DESCRIPTION
This PR implements a few different optimization to the image loading process:

- Moves image loading + processing to the DownloadThread, resulting in less freezes while loading long/large images/gifs.
- Images are now cached [WIP]
- Gif frames are now uploaded to the GPU over multiple ticks instead of all at once
- Adds a limit of `5` concurrently downloading images