### PR TITLE
 Image + Gif loading optimizations and auto free GPU memory  for 1.10.2

### DIFF
--- a/src/main/java/com/creativemd/opf/block/TileEntityPicFrame.java
+++ b/src/main/java/com/creativemd/opf/block/TileEntityPicFrame.java
@@ -28,6 +28,7 @@ public class TileEntityPicFrame extends TileEntityCreative implements ITickable{
 	@SideOnly(Side.CLIENT)
 	public DownloadThread downloader;
 	
+	
 	@SideOnly(Side.CLIENT)
 	public PictureTexture texture;
 	

--- a/src/main/java/com/creativemd/opf/block/TileEntityPicFrame.java
+++ b/src/main/java/com/creativemd/opf/block/TileEntityPicFrame.java
@@ -191,7 +191,6 @@ public class TileEntityPicFrame extends TileEntityCreative implements ITickable{
 	
 	public int renderDistance = 128;
 	
-	public String owner = "";
 	public String url = "";
 	public float sizeX = 1F;
 	public float sizeY = 1F;
@@ -213,7 +212,6 @@ public class TileEntityPicFrame extends TileEntityCreative implements ITickable{
 	public byte posY = 0;
 	
 	public boolean visibleFrame = true;
-	public boolean isPrivate = true;
 	
 	public void setOwner(String playername)
 	{
@@ -231,7 +229,6 @@ public class TileEntityPicFrame extends TileEntityCreative implements ITickable{
 		nbt.setByte("offsetY", posY);
 		nbt.setByte("rotation", rotation);
 		nbt.setBoolean("visibleFrame", visibleFrame);
-		nbt.setBoolean("isPrivate", isPrivate);
 		nbt.setBoolean("flippedX", flippedX);
 		nbt.setBoolean("flippedY", flippedY);
 		nbt.setFloat("rotX", rotationX);
@@ -251,8 +248,6 @@ public class TileEntityPicFrame extends TileEntityCreative implements ITickable{
 		posY = nbt.getByte("offsetY");
 		rotation = nbt.getByte("rotation");
 		visibleFrame = nbt.getBoolean("visibleFrame");
-		isPrivate = nbt.getBoolean("isPrivate");
-		
 		flippedX = nbt.getBoolean("flippedX");
 		flippedY = nbt.getBoolean("flippedY");
 		rotationX = nbt.getFloat("rotX");
@@ -271,7 +266,6 @@ public class TileEntityPicFrame extends TileEntityCreative implements ITickable{
 		nbt.setByte("offsetY", posY);
 		nbt.setByte("rotation", rotation);
 		nbt.setBoolean("visibleFrame", visibleFrame);
-		nbt.setBoolean("isPrivate", isPrivate);
 		nbt.setBoolean("flippedX", flippedX);
 		nbt.setBoolean("flippedY", flippedY);
 		nbt.setFloat("rotX", rotationX);
@@ -291,7 +285,6 @@ public class TileEntityPicFrame extends TileEntityCreative implements ITickable{
 		posY = nbt.getByte("offsetY");
 		rotation = nbt.getByte("rotation");
 		visibleFrame = nbt.getBoolean("visibleFrame");
-		isPrivate = nbt.getBoolean("isPrivate");
 		flippedX = nbt.getBoolean("flippedX");
 		flippedY = nbt.getBoolean("flippedY");
 		rotationX = nbt.getFloat("rotX");

--- a/src/main/java/com/creativemd/opf/client/AnimatedPictureTexture.java
+++ b/src/main/java/com/creativemd/opf/client/AnimatedPictureTexture.java
@@ -2,23 +2,29 @@ package com.creativemd.opf.client;
 
 import com.porpit.lib.GifDecoder;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
 public class AnimatedPictureTexture extends PictureTexture {
 	
 	private final int[] textureIDs;
 	private final long[] delay;
 	private final long duration;
+	private int completedFrames;
+	private ProcessedImageData imageData;
 	
-	public AnimatedPictureTexture(GifDecoder decoder) {
-		super((int) decoder.getFrameSize().getWidth(), (int) decoder.getFrameSize().getHeight());
-		textureIDs = new int[decoder.getFrameCount()];
-		delay = new long[decoder.getFrameCount()];
-		long time = 0;
+	public AnimatedPictureTexture(ProcessedImageData image,BlockPos bp,int dim) {
+		
+		super(image.getWidth(), image.getHeight(),bp,dim);
+		imageData = image;
+		textureIDs = new int[image.getFrameCount()];
+		delay = image.getDelay();
+		duration = image.getDuration();
 		for (int i = 0; i < textureIDs.length; i++) {
-			textureIDs[i] = DownloadThread.loadTexture(decoder.getFrame(i));
-			delay[i] = time;
-			time += decoder.getDelay(i);
+			textureIDs[i] = -1;
 		}
-		duration = time;
+		
 	}
 
 	@Override
@@ -32,7 +38,37 @@ public class AnimatedPictureTexture extends PictureTexture {
 				break;
 			}
 		}
+		this.lastticktime=Minecraft.getSystemTime();
 		return textureIDs[index];
 	}
-
+	@Override
+	public void tick() {
+		if (imageData != null) {
+			//Upload as many frames as possible in 10 ms
+			long startTime = System.currentTimeMillis();
+			int index = 0;
+			while (completedFrames < textureIDs.length && index < textureIDs.length && System.currentTimeMillis() - startTime < 10) {
+				while (textureIDs[index] != -1 && index < textureIDs.length - 1) {
+					index++;
+				}
+				if (textureIDs[index] == -1) {
+					textureIDs[index] = uploadFrame(index);
+				}
+			}
+		}
+	}
+	
+	public int[] getTextureIDs() {
+		return textureIDs;
+	}
+	private int uploadFrame(int index) {
+		int id;
+		id = imageData.uploadFrame(index);
+		textureIDs[index] = id;
+		if (++completedFrames >= imageData.getFrameCount()) {
+			//Unload imageData after all frames have been loaded
+			imageData = null;
+		}
+		return id;
+	}
 }

--- a/src/main/java/com/creativemd/opf/client/OrdinaryTexture.java
+++ b/src/main/java/com/creativemd/opf/client/OrdinaryTexture.java
@@ -2,17 +2,25 @@ package com.creativemd.opf.client;
 
 import java.awt.image.BufferedImage;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
 public class OrdinaryTexture extends PictureTexture {
 
 	private final int textureID;
 	
-	public OrdinaryTexture(BufferedImage image) {
-		super(image.getWidth(), image.getHeight());
-		this.textureID = DownloadThread.loadTexture(image);
+	
+	public OrdinaryTexture(ProcessedImageData image,BlockPos bp,int dim) {
+		super(image.getWidth(), image.getHeight(),bp, dim);
+		textureID = image.uploadFrame(0);
 	}
-
+	@Override
+	public void tick() {
+	}
 	@Override
 	public int getTextureID() {
+		this.lastticktime=Minecraft.getSystemTime();
 		return textureID;
 	}
 }

--- a/src/main/java/com/creativemd/opf/client/PicTileRenderer.java
+++ b/src/main/java/com/creativemd/opf/client/PicTileRenderer.java
@@ -6,101 +6,168 @@ import org.lwjgl.opengl.GL12;
 import com.creativemd.creativecore.client.rendering.RenderHelper3D;
 import com.creativemd.opf.block.TileEntityPicFrame;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
 public class PicTileRenderer extends TileEntitySpecialRenderer<TileEntityPicFrame> {
-	
+	static boolean isdeleting=false;
+	static long lasttime =Minecraft.getSystemTime();
 	public static void renderTileEntityAt(TileEntityPicFrame frame, double x, double y, double z, float partialTicks, int meta, boolean isLittle) { 
 		if(!frame.url.equals(""))
 		{
 			if(frame.isTextureLoaded())
 			{
-				float sizeX = frame.sizeX;
-				float sizeY = frame.sizeY;
-				
-				GlStateManager.enableBlend();
-	            OpenGlHelper.glBlendFunc(770, 771, 1, 0);
-	            GlStateManager.disableLighting();
-	            GlStateManager.color(1, 1, 1, 1);
-	            GlStateManager.bindTexture(frame.texture.getTextureID());
-	            
-	            GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_NEAREST);
-	            GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_NEAREST);
-	            
-	            GlStateManager.pushMatrix();
-	            
-	    		GL11.glTranslated(x+0.5, y+0.5, z+0.5);
-	    		
-	    		EnumFacing direction = EnumFacing.getFront(meta);
-	    		RenderHelper3D.applyDirection(direction);
-	    		if(direction == EnumFacing.UP || direction == EnumFacing.DOWN)
-	    			GL11.glRotatef(90, 0, 1, 0);
-	    		
-	    		double posX = -0.5+sizeX/2D;
-	    		if(frame.posX == 1)
-	    			posX = 0;
-	    		else if(frame.posX == 2)
-	    			posX = -posX;
-	    		double posY = -0.5+sizeY/2D;
-	    		if(frame.posY == 1)
-	    			posY = 0;
-	    		else if(frame.posY == 2)
-	    			posY = -posY;
-	    		
-	    		if((frame.rotation == 1 || frame.rotation == 3) && (frame.posX == 2 ^ frame.posY == 2))
-	    			GL11.glRotated(180, 1, 0, 0);
-	    		
-	    		GL11.glRotated(frame.rotation * 90, 1, 0, 0);
-	    		
-	    		GL11.glRotated(frame.rotationX, 0, 1, 0);
-	    		GL11.glRotated(frame.rotationY, 0, 0, 1);
-	    		
-	    		GL11.glTranslated(-0.945, posY, posX);
-	    		
-	    		
-	    		GlStateManager.enableRescaleNormal();
-	    		GL11.glScaled(1, frame.sizeY, frame.sizeX);
-	    		
-	    		GL11.glBegin(GL11.GL_POLYGON);
-	    		GL11.glNormal3f(1.0f, 0.0F, 0.0f);
-	    		
-	    		GL11.glTexCoord3f(frame.flippedY ? 0 : 1, frame.flippedX ? 0 : 1, 0);
-	    		GL11.glVertex3f(0.5F, -0.5f, -0.5f);
-	    		GL11.glTexCoord3f(frame.flippedY ? 0 : 1, frame.flippedX ? 1 : 0, 0);
-	    		GL11.glVertex3f(0.5f, 0.5f, -0.5f);
-	    		GL11.glTexCoord3f(frame.flippedY ? 1 : 0, frame.flippedX ? 1 : 0, 0);
-	    		GL11.glVertex3f(0.5f, 0.5f, 0.5f);
-	    		GL11.glTexCoord3f(frame.flippedY ? 1 : 0, frame.flippedX ? 0 : 1, 0);
-	    		GL11.glVertex3f(0.5f, -0.5f, 0.5f);
-	    		GL11.glEnd();
-	    		
-	    		GlStateManager.popMatrix();
-	    		
-	    		GlStateManager.disableRescaleNormal();
-	            GlStateManager.disableBlend();
-	            GlStateManager.enableLighting();
+				int textureID = frame.texture.getTextureID();
+
+				if (textureID != -1) {
+					float sizeX = frame.sizeX;
+					float sizeY = frame.sizeY;
+
+					GlStateManager.enableBlend();
+					OpenGlHelper.glBlendFunc(770, 771, 1, 0);
+					GlStateManager.disableLighting();
+					GlStateManager.color(1, 1, 1, 1);
+					GlStateManager.bindTexture(textureID);
+
+					GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_NEAREST);
+					GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_NEAREST);
+
+					GlStateManager.pushMatrix();
+
+					GL11.glTranslated(x + 0.5, y + 0.5, z + 0.5);
+
+					EnumFacing direction = EnumFacing.getFront(meta);
+					RenderHelper3D.applyDirection(direction);
+					if (direction == EnumFacing.UP || direction == EnumFacing.DOWN)
+						GL11.glRotatef(90, 0, 1, 0);
+
+					double posX = -0.5 + sizeX / 2D;
+					if (frame.posX == 1)
+						posX = 0;
+					else if (frame.posX == 2)
+						posX = -posX;
+					double posY = -0.5 + sizeY / 2D;
+					if (frame.posY == 1)
+						posY = 0;
+					else if (frame.posY == 2)
+						posY = -posY;
+
+					if ((frame.rotation == 1 || frame.rotation == 3) && (frame.posX == 2 ^ frame.posY == 2))
+						GL11.glRotated(180, 1, 0, 0);
+
+					GL11.glRotated(frame.rotation * 90, 1, 0, 0);
+
+					GL11.glRotated(frame.rotationX, 0, 1, 0);
+					GL11.glRotated(frame.rotationY, 0, 0, 1);
+
+					GL11.glTranslated(-0.945, posY, posX);
+
+
+					GlStateManager.enableRescaleNormal();
+					GL11.glScaled(1, frame.sizeY, frame.sizeX);
+
+					GL11.glBegin(GL11.GL_POLYGON);
+					GL11.glNormal3f(1.0f, 0.0F, 0.0f);
+
+					GL11.glTexCoord3f(frame.flippedY ? 0 : 1, frame.flippedX ? 0 : 1, 0);
+					GL11.glVertex3f(0.5F, -0.5f, -0.5f);
+					GL11.glTexCoord3f(frame.flippedY ? 0 : 1, frame.flippedX ? 1 : 0, 0);
+					GL11.glVertex3f(0.5f, 0.5f, -0.5f);
+					GL11.glTexCoord3f(frame.flippedY ? 1 : 0, frame.flippedX ? 1 : 0, 0);
+					GL11.glVertex3f(0.5f, 0.5f, 0.5f);
+					GL11.glTexCoord3f(frame.flippedY ? 1 : 0, frame.flippedX ? 0 : 1, 0);
+					GL11.glVertex3f(0.5f, -0.5f, 0.5f);
+					GL11.glEnd();
+
+					GlStateManager.popMatrix();
+
+					GlStateManager.disableRescaleNormal();
+					GlStateManager.disableBlend();
+					GlStateManager.enableLighting();
+				}
 			}else{
-				frame.loadTexutre();
+				frame.loadTexture();
 			}
 		}
 	}
+	
 
 	@Override
 	public void renderTileEntityAt(TileEntityPicFrame frame, double x, double y, double z, float partialTicks, int destroyStage) {
 		renderTileEntityAt(frame, x, y, z, partialTicks, frame.getBlockMetadata(), false);
+		if(isdeleting==false&&Minecraft.getSystemTime()-lasttime>=8000)
+		{
+			lasttime=Minecraft.getSystemTime();
+			isdeleting=true;
+		try {
+			System.out.println(Minecraft.getSystemTime());
+			System.out.println(Minecraft.getMinecraft().thePlayer);
+			java.util.Iterator it = DownloadThread.loadedImages.entrySet().iterator();
+			while (it.hasNext()) {
+				java.util.Map.Entry entry = (java.util.Map.Entry) it.next();
+				// entry.getKey() 返回与此项对应的键
+				PictureTexture pttemp = (PictureTexture) entry.getValue();
+				BlockPos bptemp = Minecraft.getMinecraft().thePlayer.getPosition();
+				System.out.println(pttemp);
+				System.out.println(pttemp instanceof AnimatedPictureTexture);
+				if (pttemp instanceof AnimatedPictureTexture) {
+					if (Minecraft.getSystemTime() - pttemp.lastticktime >= 6000
+							&& (Math.abs(pttemp.bp.getX() - bptemp.getX()) >= 64
+							|| Math.abs(pttemp.bp.getZ() - bptemp.getZ()) >= 64||this.getWorld().provider.getDimension()!=pttemp.dim)) {
+						for (int i : ((AnimatedPictureTexture) pttemp).getTextureIDs()) {
+							GlStateManager.deleteTexture(i);
+
+						}
+						
+						System.out.println("GIF显存清理");
+						it.remove();
+						/*if(pttemp.dim.getTileEntity(pttemp.bp) instanceof TileEntityPicFrame)
+						{
+							((TileEntityPicFrame) pttemp.dim.getTileEntity(pttemp.bp)).initClient();
+						}*/
+					}
+				} else if (pttemp instanceof OrdinaryTexture) {
+					System.out.println(pttemp.bp);
+					if (Minecraft.getSystemTime() - pttemp.lastticktime >= 6000
+							&& (Math.abs(pttemp.bp.getX() - bptemp.getX()) >= 64
+							|| Math.abs(pttemp.bp.getZ() - bptemp.getZ()) >= 64||this.getWorld().provider.getDimension()!=pttemp.dim)) {
+						GlStateManager.deleteTexture(pttemp.getTextureID());
+						System.out.println("显存清理");
+						it.remove();
+/*						if(pttemp.dim.getTileEntity(pttemp.bp) instanceof TileEntityPicFrame)
+						{
+							((TileEntityPicFrame) pttemp.dim.getTileEntity(pttemp.bp)).initClient();
+						}*/
+					}
+					
+				}
+				// entry.getValue() 返回与此项对应的值
+				
+				System.out.print(entry.getValue());
+			}
+			isdeleting=false;
+		} catch (Exception e) {
+			// TODO 自动生成的 catch 块
+			isdeleting=false;
+			e.printStackTrace();
+		}
+		}
 	}
+	
+	
 	
 	@Override
 	public boolean isGlobalRenderer(TileEntityPicFrame te)
     {
 		return te.sizeX > 16 || te.sizeY > 16;
     }
-
 }

--- a/src/main/java/com/creativemd/opf/client/PicTileRenderer.java
+++ b/src/main/java/com/creativemd/opf/client/PicTileRenderer.java
@@ -19,8 +19,8 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
 public class PicTileRenderer extends TileEntitySpecialRenderer<TileEntityPicFrame> {
-	static boolean isdeleting=false;
-	static long lasttime =Minecraft.getSystemTime();
+	boolean isdeleting=false;
+	long lasttime =Minecraft.getSystemTime();
 	public static void renderTileEntityAt(TileEntityPicFrame frame, double x, double y, double z, float partialTicks, int meta, boolean isLittle) { 
 		if(!frame.url.equals(""))
 		{
@@ -104,7 +104,7 @@ public class PicTileRenderer extends TileEntitySpecialRenderer<TileEntityPicFram
 	@Override
 	public void renderTileEntityAt(TileEntityPicFrame frame, double x, double y, double z, float partialTicks, int destroyStage) {
 		renderTileEntityAt(frame, x, y, z, partialTicks, frame.getBlockMetadata(), false);
-		if(isdeleting==false&&Minecraft.getSystemTime()-lasttime>=8000)
+		if(isdeleting==false&&Minecraft.getSystemTime()-lasttime>=60000)
 		{
 			lasttime=Minecraft.getSystemTime();
 			isdeleting=true;
@@ -120,7 +120,7 @@ public class PicTileRenderer extends TileEntitySpecialRenderer<TileEntityPicFram
 				System.out.println(pttemp);
 				System.out.println(pttemp instanceof AnimatedPictureTexture);
 				if (pttemp instanceof AnimatedPictureTexture) {
-					if (Minecraft.getSystemTime() - pttemp.lastticktime >= 6000
+					if (Minecraft.getSystemTime() - pttemp.lastticktime >= 60000
 							&& (Math.abs(pttemp.bp.getX() - bptemp.getX()) >= 64
 							|| Math.abs(pttemp.bp.getZ() - bptemp.getZ()) >= 64||this.getWorld().provider.getDimension()!=pttemp.dim)) {
 						for (int i : ((AnimatedPictureTexture) pttemp).getTextureIDs()) {
@@ -137,7 +137,7 @@ public class PicTileRenderer extends TileEntitySpecialRenderer<TileEntityPicFram
 					}
 				} else if (pttemp instanceof OrdinaryTexture) {
 					System.out.println(pttemp.bp);
-					if (Minecraft.getSystemTime() - pttemp.lastticktime >= 6000
+					if (Minecraft.getSystemTime() - pttemp.lastticktime >= 60000
 							&& (Math.abs(pttemp.bp.getX() - bptemp.getX()) >= 64
 							|| Math.abs(pttemp.bp.getZ() - bptemp.getZ()) >= 64||this.getWorld().provider.getDimension()!=pttemp.dim)) {
 						GlStateManager.deleteTexture(pttemp.getTextureID());

--- a/src/main/java/com/creativemd/opf/client/PictureTexture.java
+++ b/src/main/java/com/creativemd/opf/client/PictureTexture.java
@@ -2,19 +2,27 @@ package com.creativemd.opf.client;
 
 import java.awt.image.BufferedImage;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
 public abstract class PictureTexture {
 	
-	
+	public final BlockPos bp;
+	public final int dim;
+	public long lastticktime;
 	public final int width;
 	public final int height;
 	
-	public PictureTexture(int width, int height)
+	public PictureTexture(int width, int height,BlockPos bp,int dim)
 	{
+		this.dim=dim;
+		this.bp=bp;
+		this.lastticktime=Minecraft.getSystemTime();
 		this.width = width;
 		this.height = height;
-		
 	}
-	
+	public abstract void tick();
 	public abstract int getTextureID();
 	
 }

--- a/src/main/java/com/creativemd/opf/client/ProcessedImageData.java
+++ b/src/main/java/com/creativemd/opf/client/ProcessedImageData.java
@@ -1,0 +1,137 @@
+package com.creativemd.opf.client;
+
+import com.porpit.lib.GifDecoder;
+import org.lwjgl.BufferUtils;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
+
+import java.awt.Dimension;
+import java.awt.image.BufferedImage;
+import java.nio.ByteBuffer;
+
+public class ProcessedImageData {
+	private final int width;
+	private final int height;
+	private final Frame[] frames;
+	private final long[] delay;
+	private final long duration;
+
+	public ProcessedImageData(BufferedImage image) {
+		width = image.getWidth();
+		height = image.getHeight();
+		frames = new Frame[] { loadFrom(image) };
+		delay = new long[] { 0 };
+		duration = 0;
+	}
+
+	public ProcessedImageData(GifDecoder decoder) {
+		Dimension frameSize = decoder.getFrameSize();
+		width = (int) frameSize.getWidth();
+		height = (int) frameSize.getHeight();
+		frames = new Frame[decoder.getFrameCount()];
+		delay = new long[decoder.getFrameCount()];
+		long time = 0;
+		for (int i = 0; i < decoder.getFrameCount(); i++) {
+			frames[i] = loadFrom(decoder.getFrame(i));
+			delay[i] = time;
+			time += decoder.getDelay(i);
+		}
+		duration = time;
+	}
+
+	public int getWidth() {
+		return width;
+	}
+
+	public int getHeight() {
+		return height;
+	}
+
+	public long[] getDelay() {
+		return delay;
+	}
+
+	public long getDuration() {
+		return duration;
+	}
+
+	public boolean isAnimated() {
+		return frames.length > 1;
+	}
+
+	public int getFrameCount() {
+		return frames.length;
+	}
+
+	public int uploadFrame(int index) {
+		if (index >= 0 && index < frames.length) {
+			Frame frame = frames[index];
+			if (frame != null) {
+				frames[index] = null;
+				return uploadFrame(frame.buffer, frame.hasAlpha, width, height);
+			}
+		}
+		return -1;
+	}
+
+	private static int uploadFrame(ByteBuffer buffer, boolean hasAlpha, int width, int height) {
+		int textureID = GL11.glGenTextures(); //Generate texture ID
+		GL11.glBindTexture(GL11.GL_TEXTURE_2D, textureID); //Bind texture ID
+
+		//Setup wrap mode
+		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, GL12.GL_CLAMP_TO_EDGE);
+		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, GL12.GL_CLAMP_TO_EDGE);
+
+		//Setup texture scaling filtering
+		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR);
+		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_LINEAR);
+
+		if (!hasAlpha) {
+			GL11.glPixelStorei(GL11.GL_UNPACK_ALIGNMENT, 1);
+		}
+
+		//Send texel data to OpenGL
+		GL11.glTexImage2D(GL11.GL_TEXTURE_2D, 0, hasAlpha ? GL11.GL_RGBA8 : GL11.GL_RGB8, width, height, 0, hasAlpha ? GL11.GL_RGBA : GL11.GL_RGB, GL11.GL_UNSIGNED_BYTE, buffer);
+
+		//Return the texture ID so we can bind it later again
+		return textureID;
+	}
+
+	private static Frame loadFrom(BufferedImage image) {
+		int width = image.getWidth();
+		int height = image.getHeight();
+		int[] pixels = new int[width * height];
+		image.getRGB(0, 0, width, height, pixels, 0, width);
+		boolean hasAlpha = false;
+		if (image.getColorModel().hasAlpha()) {
+			for (int pixel : pixels) {
+				if ((pixel >> 24 & 0xFF) < 0xFF) {
+					hasAlpha = true;
+					break;
+				}
+			}
+		}
+		int bytesPerPixel = hasAlpha ? 4 : 3;
+		ByteBuffer buffer = BufferUtils.createByteBuffer(width * height * bytesPerPixel);
+		for (int pixel : pixels) {
+			buffer.put((byte) ((pixel >> 16) & 0xFF));     // Red component
+			buffer.put((byte) ((pixel >> 8) & 0xFF));      // Green component
+			buffer.put((byte) (pixel & 0xFF));             // Blue component
+			if (hasAlpha) {
+				buffer.put((byte) ((pixel >> 24) & 0xFF)); // Alpha component. Only for RGBA
+			}
+		}
+		buffer.flip();
+		return new Frame(buffer, hasAlpha);
+	}
+
+	private static class Frame {
+		private final ByteBuffer buffer;
+		private final boolean hasAlpha;
+
+		public Frame(ByteBuffer buffer, boolean alpha) {
+			this.buffer = buffer;
+			this.hasAlpha = alpha;
+		}
+	}
+}

--- a/src/main/java/com/creativemd/opf/client/catch/TextureCache.java
+++ b/src/main/java/com/creativemd/opf/client/catch/TextureCache.java
@@ -1,0 +1,163 @@
+package com.creativemd.opf.client.cache;
+
+import com.creativemd.opf.client.DownloadThread;
+import net.minecraft.client.Minecraft;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.IOUtils;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class TextureCache {
+	private File cacheDirectory = new File(Minecraft.getMinecraft().mcDataDir, "opframe_cache");
+	private File index = new File(cacheDirectory, "index");
+
+	private Map<String, CacheEntry> entries = new HashMap<String, CacheEntry>();
+
+	public TextureCache() {
+		if (!cacheDirectory.exists()) {
+			cacheDirectory.mkdirs();
+		}
+		loadIndex();
+	}
+
+	public void save(String url, String etag, long time, long expireTime, byte[] data) {
+		CacheEntry entry = new CacheEntry(url, etag, time, expireTime);
+		boolean saved = false;
+		OutputStream out = null;
+		try {
+			out = new FileOutputStream(entry.getFile());
+			out.write(data);
+			saved = true;
+		}
+		catch (IOException e) {
+			DownloadThread.LOGGER.error("Failed to save cache entry {}", e, url);
+		}
+		finally {
+			IOUtils.closeQuietly(out);
+		}
+		if (saved) {
+			entries.put(url, entry);
+			saveIndex();
+		}
+	}
+
+	public CacheEntry getEntry(String url) {
+		return entries.get(url);
+	}
+
+	private void loadIndex() {
+		if (index.exists()) {
+			Map<String, CacheEntry> previousEntries = entries;
+			entries = new HashMap<String, CacheEntry>();
+			DataInputStream in = null;
+			try {
+				in = new DataInputStream(new GZIPInputStream(new FileInputStream(index)));
+				int length = in.readInt();
+				for (int i = 0; i < length; i++) {
+					String url = in.readUTF();
+					String etag = in.readUTF();
+					long time = in.readLong();
+					long expireTime = in.readLong();
+					CacheEntry entry = new CacheEntry(url, etag.length() > 0 ? etag : null, time, expireTime);
+					entries.put(entry.getUrl(), entry);
+				}
+			}
+			catch (IOException e) {
+				DownloadThread.LOGGER.error("Failed to load cache index", e);
+				entries = previousEntries;
+			}
+			finally {
+				IOUtils.closeQuietly(in);
+			}
+		}
+	}
+
+	private void saveIndex() {
+		DataOutputStream out = null;
+		try {
+			out = new DataOutputStream(new GZIPOutputStream(new FileOutputStream(index)));
+			out.writeInt(entries.size());
+			for (Map.Entry<String, CacheEntry> mapEntry : entries.entrySet()) {
+				CacheEntry entry = mapEntry.getValue();
+				out.writeUTF(entry.getUrl());
+				out.writeUTF(entry.getEtag() == null ? "" : entry.getEtag());
+				out.writeLong(entry.getTime());
+				out.writeLong(entry.getExpireTime());
+			}
+		}
+		catch (IOException e) {
+			DownloadThread.LOGGER.error("Failed to save cache index", e);
+		}
+		finally {
+			IOUtils.closeQuietly(out);
+		}
+	}
+
+	public void deleteEntry(String url) {
+		entries.remove(url);
+		File file = getFile(url);
+		if (file.exists()) {
+			file.delete();
+		}
+	}
+
+	private static File getFile(String url) {
+		return new File(DownloadThread.TEXTURE_CACHE.cacheDirectory, Base64.encodeBase64String(url.getBytes()));
+	}
+
+	public static class CacheEntry {
+		private String url;
+		private String etag;
+		private long time;
+		private long expireTime;
+
+		public CacheEntry(String url, String etag, long time, long expireTime) {
+			this.url = url;
+			this.etag = etag;
+			this.time = time;
+			this.expireTime = expireTime;
+		}
+
+		public void setEtag(String etag) {
+			this.etag = etag;
+		}
+
+		public void setTime(long time) {
+			this.time = time;
+		}
+
+		public void setExpireTime(long expireTime) {
+			this.expireTime = expireTime;
+		}
+
+		public String getUrl() {
+			return url;
+		}
+
+		public String getEtag() {
+			return etag;
+		}
+
+		public long getTime() {
+			return time;
+		}
+
+		public long getExpireTime() {
+			return expireTime;
+		}
+
+		public File getFile() {
+			return TextureCache.getFile(url);
+		}
+	}
+}


### PR DESCRIPTION
Image + Gif loading optimizations  code copy from gegy1000

and add a new features: auto free GPU memory
if a image or Gif no rendering for long time(60s)
to delete texture

(i m a novice Forge coder,I know that the delete texture code doesn't belong to there,You can correct me)